### PR TITLE
Add feature to validate proxy

### DIFF
--- a/deployment/helm/deploy-values.template.yaml
+++ b/deployment/helm/deploy-values.template.yaml
@@ -7,6 +7,10 @@ pctasks:
     appRootPath: "/tasks"
     debug: "FALSE"
 
+    access_key:
+      enabled: true
+      value: "{{ tf.kv_access_key }}"
+
     image:
       repository: "{{ tf.component_acr_name }}.azurecr.io/pctasks-server"
       tag: "{{ tf.pctasks_server_image_tag }}"

--- a/deployment/helm/published/pctasks-server/templates/deployment.yaml
+++ b/deployment/helm/published/pctasks-server/templates/deployment.yaml
@@ -57,6 +57,11 @@ spec:
             - name: PCTASKS_SERVER__RECORD_TABLES__CONNECTION_STRING
               value: "{{ .Values.pctasks.run.tables.connection_string }}"
 
+            {{- if .Values.pctasks.server.access_key.enabled }}
+            - name: PCTASKS_SERVER__ACCESS_KEY
+              value: "{{ .Values.pctasks.server.access_key.value }}"
+            {{- end }}
+
             ## Azure service principal
             - name: AZURE_TENANT_ID
               value: "{{ .Values.pctasks.server.azure.tenant_id }}"

--- a/deployment/helm/published/pctasks-server/values.yaml
+++ b/deployment/helm/published/pctasks-server/values.yaml
@@ -7,6 +7,9 @@ pctasks:
     appRootPath: ""
     debug: "FALSE"
     webConcurrency: "1"
+    access_key:
+      enabled: false
+      value: ""
 
     dev:
       enabled: false

--- a/deployment/terraform/batch_pool/providers.tf
+++ b/deployment/terraform/batch_pool/providers.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.90.0"
+      version = "3.15.0"
     }
   }
 }

--- a/deployment/terraform/resources/aks.tf
+++ b/deployment/terraform/resources/aks.tf
@@ -5,16 +5,7 @@ resource "azurerm_kubernetes_cluster" "pctasks" {
   dns_prefix          = "${local.prefix}-cluster"
   kubernetes_version  = var.k8s_version
 
-  addon_profile {
-    kube_dashboard {
-      enabled = false
-    }
 
-    oms_agent {
-      enabled                    = true
-      log_analytics_workspace_id = azurerm_log_analytics_workspace.pctasks.id
-    }
-  }
 
   default_node_pool {
     name           = "agentpool"

--- a/deployment/terraform/resources/ip.tf
+++ b/deployment/terraform/resources/ip.tf
@@ -14,6 +14,6 @@ resource "azurerm_public_ip" "pctasks" {
     # See https://github.com/terraform-providers/terraform-provider-azurerm/issues/7034
     # and https://github.com/terraform-providers/terraform-provider-azurerm/pull/11020#issuecomment-802606941
 
-    k8s-azure-dns-label-service = "pcaux/nginx-ingress-ingress-nginx-controller"
+    # k8s-azure-dns-label-service = "pc/nginx-ingress-ingress-nginx-controller"
   }
 }

--- a/deployment/terraform/resources/keyvault.tf
+++ b/deployment/terraform/resources/keyvault.tf
@@ -53,3 +53,15 @@ resource "azurerm_key_vault_secret" "task-client-secret" {
   value        = var.task_sp_client_secret
   key_vault_id = azurerm_key_vault.pctasks.id
 }
+
+# API Management access key
+
+data "azurerm_key_vault" "deploy_secrets" {
+  name                = var.deploy_secrets_kv_name
+  resource_group_name = var.deploy_secrets_kv_rg
+}
+
+data "azurerm_key_vault_secret" "access_key" {
+  name         = var.access_key_secret_name
+  key_vault_id = data.azurerm_key_vault.deploy_secrets.id
+}

--- a/deployment/terraform/resources/output.tf
+++ b/deployment/terraform/resources/output.tf
@@ -128,6 +128,10 @@ output "kv_sp_client_secret" {
   value = var.kv_sp_client_secret
 }
 
+output "kv_access_key" {
+  value = data.azurerm_key_vault_secret.access_key.value
+}
+
 ## API Management
 
 output "api_management_name" {

--- a/deployment/terraform/resources/providers.tf
+++ b/deployment/terraform/resources/providers.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.90.0"
+      version = "3.15.0"
     }
   }
 }

--- a/deployment/terraform/resources/values.tfvars.template
+++ b/deployment/terraform/resources/values.tfvars.template
@@ -64,10 +64,10 @@ pctasks_server_sp_object_id = ""
 
 stac_db_connection_string = ""
 
-# Batch pool settings
-# ------------------
-# This controls the name of the default batch pool and the
-# minimum number of low priority nodes for the pool.
-
-batch_default_pool_id = "tasks_pool"
-min_low_priority = 0
+# PCTasks access key info
+# --------------------------
+# This is the key that is used to verify requests are legit.
+# This key is embedded by API Management and verified on the server.
+deploy_secrets_kv_name = ""
+deploy_secrets_kv_rg = ""
+access_key_secret_name = ""

--- a/deployment/terraform/resources/variables.tf
+++ b/deployment/terraform/resources/variables.tf
@@ -108,6 +108,18 @@ variable "kv_sp_client_secret" {
   type    = string
 }
 
+variable "deploy_secrets_kv_name" {
+  type    = string
+}
+
+variable deploy_secrets_kv_rg {
+  type    = string
+}
+
+variable access_key_secret_name {
+  type    = string
+}
+
 ## PCTasks Server
 
 variable "pctasks_server_sp_tenant_id" {

--- a/deployment/terraform/staging/main.tf
+++ b/deployment/terraform/staging/main.tf
@@ -4,6 +4,9 @@ module "resources" {
   environment = "staging"
   region = "West Europe"
 
+  pctasks_server_image_tag = "latest"
+  pctasks_run_image_tag = "latest"
+
   batch_default_pool_id = var.batch_default_pool_id
 
   task_acr_resource_group = var.task_acr_resource_group
@@ -19,6 +22,10 @@ module "resources" {
   kv_sp_tenant_id = var.kv_sp_tenant_id
   kv_sp_client_id = var.kv_sp_client_id
   kv_sp_client_secret = var.kv_sp_client_secret
+
+  deploy_secrets_kv_name = var.deploy_secrets_kv_name
+  deploy_secrets_kv_rg = var.deploy_secrets_kv_rg
+  access_key_secret_name = var.access_key_secret_name
 
   pctasks_server_sp_tenant_id = var.pctasks_server_sp_tenant_id
   pctasks_server_sp_client_id = var.pctasks_server_sp_client_id

--- a/deployment/terraform/staging/variables.tf
+++ b/deployment/terraform/staging/variables.tf
@@ -94,6 +94,18 @@ variable "kv_sp_client_secret" {
   type    = string
 }
 
+variable "deploy_secrets_kv_name" {
+  type    = string
+}
+
+variable deploy_secrets_kv_rg {
+  type    = string
+}
+
+variable access_key_secret_name {
+  type    = string
+}
+
 ## Database
 
 variable "stac_db_connection_string" {

--- a/pctasks/server/pctasks/server/settings.py
+++ b/pctasks/server/pctasks/server/settings.py
@@ -90,6 +90,8 @@ class ServerSettings(PCTasksSettings):
     dev: bool = False
     dev_api_key: Optional[str] = None
 
+    access_key: Optional[str] = None
+
     record_tables: RecordTablesConfig
 
     app_insights_instrumentation_key: Optional[str] = Field(


### PR DESCRIPTION
This change adds an access key that can be used to validate the origin of incoming requests. This allows route-based restrictions on request forwarding for routes that have scoped access.