### PR TITLE
Add record status command; add default args in settings

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -35,9 +35,6 @@ RUN cd /opt/src && pip install -r requirements-dev.txt
 # Copy and install packages
 #
 
-# TODO: remove this
-RUN apt-get install -y git
-
 COPY pctasks/core /opt/src/pctasks/core
 RUN cd /opt/src/pctasks/core && \
      pip install -e .

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -10,7 +10,7 @@ Profiles allow you to easily switch the environment PCTasks is targeting.
 
 A profile is expected to have a YAML file in the settings folder with the name of the profile. For example, if for the profile `staging`, PCTasks would use the file `~/.pctasks/staging.yaml` for settings.
 
-## Creating profiles
+### Creating profiles
 
 You can create a new profile for the client settings using `pctasks`. Run:
 
@@ -19,6 +19,25 @@ You can create a new profile for the client settings using `pctasks`. Run:
 ```
 to create a new profile named `${PROFILE}`. Follow the prompts that ask for the API endpoint (e.g. <https://planetarycomputer.microsoft.com/api/tasks/v1>), your API key, and whether or not to ask for confirmation before submitting to the endpoint.
 
-## Editing profiles
+### Editing profiles
 
 You can edit a profile by using `pctasks profile edit ${PROFILE}`, which will take you through the same prompts and default to the values that currently exist in the profile.
+
+## Client Settings
+
+PCTask users will need to specify client settings for usage. A settings file created by the above commands looks like this:
+
+```
+client:
+  endpoint: https://planetarycomputer-staging.microsoft.com/api/tasks/v1
+  api_key: XXXXXX
+  confirmation_required: true
+  default_args:
+    registry: pccomponents.azurecr.io
+```
+
+The endpoint is the PCTasks API endpoint, and the API Key is the API Management token that is used to authenticate against the API.
+
+If `confirmation_required` is true, PCTasks will ask for confirmation before submitting workflows to the endpoint. This can provide a double-check to ensure the intended profile is being used.
+
+`default_args` allows a profile to specify default arguments for workflows. This is useful for common arguments in workflows, such as the container registry that should be used to pull a task image. In the above example, the user would not have to specify the `registry` argument when using the profile with these settings as they will be supplied by the defaults. Note that an argument is specified on the command line, will take precedence over a settings default.

--- a/pctasks/client/pctasks/client/client.py
+++ b/pctasks/client/pctasks/client/client.py
@@ -219,8 +219,8 @@ class PCTasksClient:
 
     def get_job(self, run_id: str, job_id: str) -> JobRunResponse:
         route = FETCH_JOB_ROUTE.format(run_id=run_id, job_id=job_id)
-        result = self._call_api("GET", route)
         try:
+            result = self._call_api("GET", route)
             return JobRunResponse.parse_obj(result)
         except HTTPError as e:
             if e.response.status_code == 404:
@@ -248,13 +248,13 @@ class PCTasksClient:
         route = FETCH_TASK_ROUTE.format(run_id=run_id, job_id=job_id, task_id=task_id)
         try:
             result = self._call_api("GET", route)
+            return TaskRunResponse.parse_obj(result)
         except HTTPError as e:
             if e.response.status_code == 404:
                 raise TaskNotFoundError(
                     f"Task {task_id} of job {job_id} for workflow run {run_id}"
                 )
             raise
-        return TaskRunResponse.parse_obj(result)
 
     def get_task_logs_from_task(self, task: TaskRunResponse) -> Dict[str, str]:
         result: Dict[str, str] = {}

--- a/pctasks/client/pctasks/client/client.py
+++ b/pctasks/client/pctasks/client/client.py
@@ -157,6 +157,10 @@ class PCTasksClient:
 
         message = message.copy(deep=True)
 
+        # Ensure arguments
+        self.settings.add_default_arguments(message)
+        message.ensure_args_match()
+
         # Inline args
         message.workflow = message.get_workflow_with_templated_args()
 

--- a/pctasks/client/pctasks/client/profile.py
+++ b/pctasks/client/pctasks/client/profile.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Optional
+from typing import Dict, Optional
 
 import click
 import yaml
@@ -35,10 +35,40 @@ def _prompt_for_settings(existing: Optional[ClientSettings] = None) -> ClientSet
         "Confirmation required?",
         default=default_conf,
     )
+
+    rprint("[underline]Default arguments:[/underline]")
+    default_args: Optional[Dict[str, str]] = None
+    if existing:
+        default_args = existing.default_args
+    if default_args:
+        for k, v in list(default_args.items())[:]:
+            rprint(f"  [bold]{k}[/bold] = [blue]{v}[/blue]")
+            action = Prompt.ask(
+                "  Modify?",
+                choices=["skip", "delete", "edit"],
+                default="skip",
+            )
+            if action == "delete":
+                default_args.pop(k)
+            elif action == "edit":
+                default_args[k] = Prompt.ask(
+                    f"Enter value for default argument {k}", default=v
+                )
+    while True:
+        add_default_arg = Confirm.ask("  Add new default?", default=False)
+        if not add_default_arg:
+            break
+        k = Prompt.ask("    Enter key")
+        v = Prompt.ask("    Enter value")
+        if default_args is None:
+            default_args = {}
+        default_args[k] = v
+
     return ClientSettings(
         endpoint=endpoint,
         api_key=api_key,
         confirmation_required=confirmation_required,
+        default_args=default_args,
     )
 
 

--- a/pctasks/client/pctasks/client/profile.py
+++ b/pctasks/client/pctasks/client/profile.py
@@ -54,7 +54,7 @@ def create_profile_command(ctx: click.Context, profile: str) -> None:
         rprint("Use `pctasks profile edit` to edit the profile")
         ctx.exit(1)
 
-    rprint(f"[green]Creating profile {profile}: [/green]")
+    rprint(f"[green]Creating profile [bold]{profile}[/bold]: [/green]")
 
     try:
         settings = _prompt_for_settings()
@@ -69,7 +69,7 @@ def create_profile_command(ctx: click.Context, profile: str) -> None:
     with open(settings_file, "w") as f:
         f.write(yaml_str)
 
-    rprint(f"\n[green]Profile {profile} created![/green]")
+    rprint(f"\n[green]Profile [bold]{profile}[/bold] created![/green]")
 
 
 @click.command(name="edit")
@@ -86,7 +86,7 @@ def edit_profile_command(ctx: click.Context, profile: str) -> None:
 
     exisiting_settings = ClientSettings.get(settings_file=settings_file)
 
-    rprint(f"[green]Editing profile {profile}: [/green]")
+    rprint(f"[green]Editing profile [/green][bold]{profile}[/bold][green]: [/green]")
 
     try:
         settings = _prompt_for_settings(exisiting_settings)
@@ -101,7 +101,8 @@ def edit_profile_command(ctx: click.Context, profile: str) -> None:
     with open(settings_file, "w") as f:
         f.write(yaml_str)
 
-    rprint(f"\n[green]Profile {profile} updated![/green]")
+    rprint(f"\n[green]Profile [/green][bold]{profile}[/bold] [green]updated![/green]")
+    print()
 
 
 @click.command(name="set")

--- a/pctasks/client/pctasks/client/records/cli.py
+++ b/pctasks/client/pctasks/client/records/cli.py
@@ -2,6 +2,7 @@ import click
 
 from pctasks.client.records.commands.fetch import fetch_cmd
 from pctasks.client.records.commands.list import list_cmd
+from pctasks.client.records.commands.status import status_cmd
 
 
 @click.group("records")
@@ -21,3 +22,4 @@ def records_cmd(ctx: click.Context, pretty_print: bool) -> None:
 
 records_cmd.add_command(list_cmd)
 records_cmd.add_command(fetch_cmd)
+records_cmd.add_command(status_cmd)

--- a/pctasks/client/pctasks/client/records/commands/_status.py
+++ b/pctasks/client/pctasks/client/records/commands/_status.py
@@ -1,0 +1,76 @@
+from typing import Optional, Tuple
+
+import click
+from click.exceptions import Exit
+from rich.console import Console
+from rich.live import Live
+from rich.table import Table
+
+from pctasks.client.client import PCTasksClient
+from pctasks.client.errors import NotFoundError
+from pctasks.client.records.constants import NOT_FOUND_EXIT_CODE
+from pctasks.client.settings import ClientSettings
+from pctasks.client.utils import status_emoji
+from pctasks.core.models.workflow import WorkflowRunStatus
+
+
+def workflow_status_cmd(
+    ctx: click.Context, run_id: str, dataset: Optional[str], watch: bool = False
+) -> int:
+    """Show status of a workflow, including all jobs and tasks."""
+    client = PCTasksClient(ClientSettings.from_context(ctx.obj))
+
+    console = Console(stderr=True)
+
+    table: Table
+    is_complete: bool
+
+    def status_entry(status: str) -> str:
+        return f"{status_emoji(status)} {status.capitalize()}"
+
+    def get_table() -> Tuple[Table, bool]:
+        _table = Table()
+        _table.add_column("")
+        _table.add_column("status")
+        try:
+            workflow = client.get_workflow(run_id, dataset)
+            wf_name = workflow.workflow.name if workflow.workflow else run_id
+        except NotFoundError as e:
+            console.print(f"[bold red]Workflow not found: {e}")
+            raise Exit(NOT_FOUND_EXIT_CODE)
+
+        _table.add_row(
+            f"[bold]Workflow: {wf_name}[/bold]", status_entry(workflow.status)
+        )
+
+        for job in sorted(client.get_jobs(run_id), key=lambda j: j.created):
+            _table.add_row(f" - Job: {job.job_id}", f" {status_entry(job.status)}")
+            for task in sorted(
+                client.get_tasks(run_id, job.job_id), key=lambda t: t.created
+            ):
+                _table.add_row(
+                    f"    - Task:{task.task_id}", f"  {status_entry(task.status)}"
+                )
+        return (
+            _table,
+            workflow.status == WorkflowRunStatus.COMPLETED
+            or workflow.status == WorkflowRunStatus.FAILED,
+        )
+
+    with console.status("Fetching records...") as fetch_status:
+        fetch_status.update(
+            status="[bold green]Fetching records...",
+            spinner="aesthetic",
+            spinner_style="green",
+        )
+        table, is_complete = get_table()
+
+    if not watch:
+        console.print(table)
+    else:
+        with Live(table, refresh_per_second=1) as live:
+            while not is_complete:
+                table, is_complete = get_table()
+                live.update(table)
+
+    return 0

--- a/pctasks/client/pctasks/client/records/commands/fetch.py
+++ b/pctasks/client/pctasks/client/records/commands/fetch.py
@@ -6,11 +6,10 @@ import click
 @click.command("workflow")
 @click.argument("run_id")
 @click.option("-d", "--dataset", help="Filter by dataset.")
+@click.option("-s", "--status", is_flag=True, help="Only report status.")
 @click.pass_context
 def fetch_workflow_cmd(
-    ctx: click.Context,
-    run_id: str,
-    dataset: Optional[str],
+    ctx: click.Context, run_id: str, dataset: Optional[str], status: bool
 ) -> int:
     """Fetch a workflow record.
 
@@ -18,7 +17,7 @@ def fetch_workflow_cmd(
     """
     from . import _fetch
 
-    return _fetch.fetch_workflow_cmd(ctx, run_id, dataset)
+    return _fetch.fetch_workflow_cmd(ctx, run_id, dataset, status)
 
 
 @click.command("job")

--- a/pctasks/client/pctasks/client/records/commands/status.py
+++ b/pctasks/client/pctasks/client/records/commands/status.py
@@ -1,0 +1,31 @@
+from typing import Optional
+
+import click
+
+
+@click.command("workflow")
+@click.argument("run_id")
+@click.option("-d", "--dataset", help="Filter by dataset.")
+@click.option(
+    "-w",
+    "--watch",
+    is_flag=True,
+    help="Watch the status of the workflow, refreshing every second",
+)
+@click.pass_context
+def fetch_workflow_cmd(
+    ctx: click.Context, run_id: str, dataset: Optional[str], watch: bool
+) -> None:
+    """Fetch a workflow status."""
+    from . import _status
+
+    ctx.exit(_status.workflow_status_cmd(ctx, run_id, dataset, watch))
+
+
+@click.group("status")
+def status_cmd() -> None:
+    """Fetch a workflow status."""
+    pass
+
+
+status_cmd.add_command(fetch_workflow_cmd)

--- a/pctasks/client/pctasks/client/records/render.py
+++ b/pctasks/client/pctasks/client/records/render.py
@@ -4,18 +4,8 @@ import pandas as pd
 from rich.console import Console
 
 from pctasks.client.records.console.dataframe import DataFrameRender
+from pctasks.client.utils import status_emoji
 from pctasks.core.models.api import JobRunResponse, TaskRunResponse, WorkflowRunResponse
-
-
-def status_emoji(status: str) -> str:
-    if status.lower() == "completed":
-        return "✅"
-    if status.lower() == "failed":
-        return "❌"
-    if status.lower() == "running":
-        return "🏃"
-    else:
-        return "🕖"
 
 
 def workflows_to_df(workflows: List[WorkflowRunResponse]) -> pd.DataFrame:

--- a/pctasks/client/pctasks/client/settings.py
+++ b/pctasks/client/pctasks/client/settings.py
@@ -1,7 +1,9 @@
+from typing import Dict, Optional
 from urllib.parse import urlparse
 
 from pydantic import validator
 
+from pctasks.core.models.workflow import WorkflowSubmitMessage
 from pctasks.core.settings import PCTasksSettings
 
 
@@ -13,6 +15,7 @@ class ClientSettings(PCTasksSettings):
     endpoint: str
     api_key: str
     confirmation_required: bool = True
+    default_args: Optional[Dict[str, str]] = None
 
     @validator("endpoint")
     def _validate_endpoint(cls, v: str) -> str:
@@ -23,3 +26,16 @@ class ClientSettings(PCTasksSettings):
         except Exception:
             raise ValueError(f"{v} is not a valid URL")
         return v
+
+    def add_default_arguments(self, submit_message: WorkflowSubmitMessage) -> None:
+        """Modifies the submit message to include default arguments."""
+        if self.default_args:
+            for arg_name, arg_value in self.default_args.items():
+                if (
+                    submit_message.workflow.args
+                    and arg_name in submit_message.workflow.args
+                ):
+                    if not submit_message.args:
+                        submit_message.args = {}
+                    if arg_name not in submit_message.args:
+                        submit_message.args[arg_name] = arg_value

--- a/pctasks/client/pctasks/client/submit/_cli.py
+++ b/pctasks/client/pctasks/client/submit/_cli.py
@@ -25,14 +25,17 @@ def cli_submit_workflow(
     """Submit a workflow to the PCTasks task queue."""
     settings = settings or ClientSettings.get()
     submit_client = PCTasksClient(settings)
-    args_errors = workflow.get_argument_errors(args)
+
+    msg = WorkflowSubmitMessage(workflow=workflow, args=args)
+    settings.add_default_arguments(msg)
+
+    args_errors = msg.workflow.get_argument_errors(msg.args)
     if args_errors:
         rprint("[red]Argument errors:[/red]")
         for error in args_errors:
             rprint(f"  [red bold]{error}[/red bold]")
         return 1
 
-    msg = WorkflowSubmitMessage(workflow=workflow, args=args)
     try:
         submit_client.submit_workflow(
             msg, confirmation_required=settings.confirmation_required

--- a/pctasks/client/pctasks/client/submit/_cli.py
+++ b/pctasks/client/pctasks/client/submit/_cli.py
@@ -1,6 +1,6 @@
 import logging
 import sys
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 import click
 import requests
@@ -12,18 +12,27 @@ from pctasks.client.errors import ConfirmationError
 from pctasks.client.settings import ClientSettings
 from pctasks.client.submit.template import template_workflow_file
 from pctasks.core.context import PCTasksCommandContext
-from pctasks.core.models.workflow import WorkflowSubmitMessage
+from pctasks.core.models.workflow import WorkflowConfig, WorkflowSubmitMessage
 
 logger = logging.getLogger(__name__)
 
 
 def cli_submit_workflow(
-    submit_client: PCTasksClient,
-    msg: WorkflowSubmitMessage,
+    workflow: WorkflowConfig,
+    args: Optional[Dict[str, str]],
     settings: Optional[ClientSettings] = None,
-) -> None:
+) -> int:
     """Submit a workflow to the PCTasks task queue."""
     settings = settings or ClientSettings.get()
+    submit_client = PCTasksClient(settings)
+    args_errors = workflow.get_argument_errors(args)
+    if args_errors:
+        rprint("[red]Argument errors:[/red]")
+        for error in args_errors:
+            rprint(f"  [red bold]{error}[/red bold]")
+        return 1
+
+    msg = WorkflowSubmitMessage(workflow=workflow, args=args)
     try:
         submit_client.submit_workflow(
             msg, confirmation_required=settings.confirmation_required
@@ -42,6 +51,7 @@ def cli_submit_workflow(
         file=sys.stderr,
     )
     cli_output(msg.run_id)
+    return 0
 
 
 def workflow_cmd(
@@ -56,6 +66,4 @@ def workflow_cmd(
 
     workflow = template_workflow_file(workflow_path)
 
-    msg = WorkflowSubmitMessage(workflow=workflow, args=dict(arg))
-    submit_client = PCTasksClient(settings)
-    cli_submit_workflow(submit_client, msg, settings)
+    ctx.exit(cli_submit_workflow(workflow, dict(arg), settings))

--- a/pctasks/client/pctasks/client/utils.py
+++ b/pctasks/client/pctasks/client/utils.py
@@ -1,0 +1,11 @@
+def status_emoji(status: str) -> str:
+    if status.lower() == "completed":
+        return "✅"
+    if status.lower() == "failed":
+        return "❌"
+    if status.lower() == "running":
+        return "🏃"
+    if status.lower() == "cancelled":
+        return "🚫"
+    else:
+        return "🕖"

--- a/pctasks/core/pctasks/core/models/api.py
+++ b/pctasks/core/pctasks/core/models/api.py
@@ -39,6 +39,7 @@ class RecordResponse(PCBaseModel):
     errors: Optional[List[str]] = None
     created: datetime
     updated: datetime
+    status: str
 
 
 class TaskRunResponse(RecordResponse):

--- a/pctasks/core/pctasks/core/models/record.py
+++ b/pctasks/core/pctasks/core/models/record.py
@@ -34,7 +34,7 @@ class TaskRunStatus(StrEnum):
     SUBMITTED = "submitted"
     """Task run was submitted to the executor (e.g. Azure Batch)."""
 
-    STARTING = "staring"
+    STARTING = "starting"
     """Task run is starting."""
 
     RUNNING = "running"

--- a/pctasks/core/pctasks/core/settings.py
+++ b/pctasks/core/pctasks/core/settings.py
@@ -2,25 +2,14 @@ import logging
 import os
 from abc import abstractmethod
 from pathlib import Path
-from typing import (
-    Any,
-    Dict,
-    Hashable,
-    List,
-    Optional,
-    OrderedDict,
-    Tuple,
-    Type,
-    TypeVar,
-    Union,
-    cast,
-)
+from typing import Any, Dict, Hashable, List, Optional, Tuple, Type, TypeVar, Union
 
-import strictyaml
+import yaml
 from cachetools import Cache, LRUCache, cachedmethod
 from cachetools.keys import hashkey
 from pydantic import BaseSettings, Field, ValidationError
 from pydantic.env_settings import SettingsSourceCallable
+from yaml import Loader
 
 from pctasks.core.constants import (
     DEFAULT_PROFILE,
@@ -158,8 +147,8 @@ def _get_yaml_settings_source(
         if settings_file.exists():
             with open(settings_file) as f:
                 yaml_txt = f.read()
-            yml: strictyaml.YAML = strictyaml.load(yaml_txt)
-            return cast(OrderedDict[str, Any], yml.data)
+            result: Dict[str, Any] = yaml.load(yaml_txt, Loader=Loader)
+            return result
         else:
             return {}
 

--- a/pctasks/dataset/pctasks/dataset/_cli.py
+++ b/pctasks/dataset/pctasks/dataset/_cli.py
@@ -6,11 +6,9 @@ from pystac.utils import str_to_datetime
 from strictyaml.exceptions import MarkedYAMLError
 
 from pctasks.cli.cli import cli_output
-from pctasks.client.client import PCTasksClient
 from pctasks.client.settings import ClientSettings
 from pctasks.client.submit._cli import cli_submit_workflow
 from pctasks.core.context import PCTasksCommandContext
-from pctasks.core.models.workflow import WorkflowSubmitMessage
 from pctasks.core.utils import map_opt
 from pctasks.core.yaml import YamlValidationError
 from pctasks.dataset.chunks.models import ChunkOptions
@@ -69,11 +67,12 @@ def create_chunks_cmd(
 
     if not submit:
         cli_output(workflow.to_yaml())
+        ctx.exit(0)
     else:
-        submit_message = WorkflowSubmitMessage(workflow=workflow, args=dict(arg))
         settings = ClientSettings.get(context.profile, context.settings_file)
-        client = PCTasksClient(settings)
-        cli_submit_workflow(client, submit_message, settings)
+        ctx.exit(
+            cli_submit_workflow(workflow=workflow, args=dict(arg), settings=settings)
+        )
 
 
 def process_items_cmd(
@@ -129,11 +128,12 @@ def process_items_cmd(
 
     if not submit:
         cli_output(workflow.to_yaml())
+        ctx.exit(0)
     else:
-        submit_message = WorkflowSubmitMessage(workflow=workflow, args=dict(arg))
         settings = ClientSettings.get(context.profile, context.settings_file)
-        client = PCTasksClient(settings)
-        cli_submit_workflow(client, submit_message, settings)
+        ctx.exit(
+            cli_submit_workflow(workflow=workflow, args=dict(arg), settings=settings)
+        )
 
 
 def ingest_collection_cmd(
@@ -182,11 +182,12 @@ def ingest_collection_cmd(
 
     if not submit:
         cli_output(workflow.to_yaml())
+        ctx.exit(0)
     else:
-        submit_message = WorkflowSubmitMessage(workflow=workflow, args=dict(arg))
         settings = ClientSettings.get(context.profile, context.settings_file)
-        client = PCTasksClient(settings)
-        cli_submit_workflow(client, submit_message, settings)
+        ctx.exit(
+            cli_submit_workflow(workflow=workflow, args=dict(arg), settings=settings)
+        )
 
 
 def list_collections_cmd(

--- a/pctasks/ingest/pctasks/ingest/_cli.py
+++ b/pctasks/ingest/pctasks/ingest/_cli.py
@@ -5,14 +5,11 @@ from typing import List, Optional
 import click
 
 from pctasks.cli.cli import cli_output
-from pctasks.client.submit._cli import cli_submit_workflow
 from pctasks.client.settings import ClientSettings
+from pctasks.client.submit._cli import cli_submit_workflow
 from pctasks.core.constants import DEFAULT_TARGET_ENVIRONMENT
 from pctasks.core.context import PCTasksCommandContext
-from pctasks.core.models.workflow import (
-    JobConfig,
-    WorkflowConfig,
-)
+from pctasks.core.models.workflow import JobConfig, WorkflowConfig
 from pctasks.ingest.models import IngestNdjsonInput, IngestTaskConfig, NdjsonFolder
 from pctasks.ingest.settings import IngestOptions, IngestSettings
 from pctasks.ingest.utils import generate_collection_json

--- a/pctasks/ingest/pctasks/ingest/_cli.py
+++ b/pctasks/ingest/pctasks/ingest/_cli.py
@@ -4,16 +4,14 @@ from typing import List, Optional
 
 import click
 
-from pctasks.cli.cli import cli_output, cli_print
-from pctasks.client.client import PCTasksClient
-from pctasks.client.settings import ClientSettings
+from pctasks.cli.cli import cli_output
 from pctasks.client.submit._cli import cli_submit_workflow
+from pctasks.client.settings import ClientSettings
 from pctasks.core.constants import DEFAULT_TARGET_ENVIRONMENT
 from pctasks.core.context import PCTasksCommandContext
 from pctasks.core.models.workflow import (
     JobConfig,
     WorkflowConfig,
-    WorkflowSubmitMessage,
 )
 from pctasks.ingest.models import IngestNdjsonInput, IngestTaskConfig, NdjsonFolder
 from pctasks.ingest.settings import IngestOptions, IngestSettings
@@ -85,21 +83,11 @@ def ingest_ndjson_cmd(
         },
     )
 
-    submit_message = WorkflowSubmitMessage(workflow=workflow)
-
     if not submit:
-        cli_output(submit_message.to_yaml())
+        cli_output(workflow.to_yaml())
     else:
         settings = ClientSettings.get(context.profile, context.settings_file)
-        client = PCTasksClient(settings)
-        cli_submit_workflow(client, submit_message, settings)
-        cli_print(
-            click.style(
-                f"  Submitting workflow to {settings.endpoint}...",
-                fg="green",
-            )
-        )
-        cli_output(client.submit_workflow(submit_message).run_id)
+        cli_submit_workflow(workflow=workflow, args=None, settings=settings)
 
 
 def ingest_collection_cmd(
@@ -141,17 +129,9 @@ def ingest_collection_cmd(
         },
     )
 
-    submit_message = WorkflowSubmitMessage(workflow=workflow)
-
     if not submit:
-        cli_output(submit_message.to_yaml())
+        cli_output(workflow.to_yaml())
+        ctx.exit(0)
     else:
         settings = ClientSettings.get(context.profile, context.settings_file)
-        client = PCTasksClient(settings)
-        cli_print(
-            click.style(
-                f"Submitting workflow to {settings.endpoint}...",
-                fg="green",
-            )
-        )
-        cli_output(client.submit_workflow(submit_message).run_id)
+        ctx.exit(cli_submit_workflow(workflow=workflow, args=None, settings=settings))


### PR DESCRIPTION
This PR makes two changes:
- Adds a command `pctasks record status` to report status of a workflow and all it's child jobs and tasks. It includes a `--watch` option that uses rich's `Live` console printer to refresh status as a job executes.
- Adds `default_args` to client settings, and the functionality for creating and editing them in the `pctasks profile [create|edit]` command. This allows for default arguments to be passed to workflows when the workflow asks for the argument and it is not supplied via another means. This is useful for per-profile arguments - the instigating example was the `registry` argument which needed to be provided on the command line each time, but really was a way to abstract a single workflow over different environments. By setting a default argument for `registry` for a profile, I no longer have to remember to pass in that argument.