### PR TITLE
fix: add geoparquet assets to the chesapeake collection templates

### DIFF
--- a/datasets/chesapeake_lulc/collection/chesapeake-lc-13/template.json
+++ b/datasets/chesapeake_lulc/collection/chesapeake-lc-13/template.json
@@ -65,7 +65,22 @@
             "roles": [
                 "thumbnail"
             ]
-        }
+        },
+        "geoparquet-items": {
+            "href": "abfs://items/chesapeake-lc-13.parquet",
+            "type": "application/x-parquet",
+            "roles": [
+                "stac-items"
+            ],
+            "title": "GeoParquet STAC items",
+            "description": "Snapshot of the collection's STAC items exported to GeoParquet format.",
+            "msft:partition_info": {
+                "is_partitioned": false
+            },
+            "table:storage_options": {
+                "account_name": "pcstacitems"
+            }
+        } 
     },
     "extent": {
         "spatial": {

--- a/datasets/chesapeake_lulc/collection/chesapeake-lc-7/template.json
+++ b/datasets/chesapeake_lulc/collection/chesapeake-lc-7/template.json
@@ -59,7 +59,22 @@
             "roles": [
                 "thumbnail"
             ]
-        }
+        },
+        "geoparquet-items": {
+            "href": "abfs://items/chesapeake-lc-7.parquet",
+            "type": "application/x-parquet",
+            "roles": [
+                "stac-items"
+            ],
+            "title": "GeoParquet STAC items",
+            "description": "Snapshot of the collection's STAC items exported to GeoParquet format.",
+            "msft:partition_info": {
+                "is_partitioned": false
+            },
+            "table:storage_options": {
+                "account_name": "pcstacitems"
+            }
+        } 
     },
     "extent": {
         "spatial": {

--- a/datasets/chesapeake_lulc/collection/chesapeake-lu/template.json
+++ b/datasets/chesapeake_lulc/collection/chesapeake-lu/template.json
@@ -59,7 +59,22 @@
             "roles": [
                     "thumbnail"
             ]
-        }
+        },
+        "geoparquet-items": {
+            "href": "abfs://items/chesapeake-lu.parquet",
+            "type": "application/x-parquet",
+            "roles": [
+                "stac-items"
+            ],
+            "title": "GeoParquet STAC items",
+            "description": "Snapshot of the collection's STAC items exported to GeoParquet format.",
+            "msft:partition_info": {
+                "is_partitioned": false
+            },
+            "table:storage_options": {
+                "account_name": "pcstacitems"
+            }
+        } 
     },
     "extent": {
         "spatial": {


### PR DESCRIPTION
## Description

Added the geoparquet assets to the collection templates for the chesapeake dataset:
- chesapeake-lc-7
- chesapeake-lc-13
- chesapeake-lu

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Not tested

## Checklist:

None completed.