### PR TITLE
Fix Record API dates and model fields

### DIFF
--- a/pctasks/core/pctasks/core/models/event.py
+++ b/pctasks/core/pctasks/core/models/event.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from typing import Any, Dict, Optional, Union
 from uuid import uuid4
 
@@ -6,6 +5,7 @@ from pydantic import BaseModel, Field
 
 from pctasks.core.constants import MICROSOFT_OWNER
 from pctasks.core.models.base import ForeachConfig, PCBaseModel, RunRecordId
+from pctasks.core.models.utils import tzutc_now
 from pctasks.core.utils import StrEnum
 
 
@@ -15,7 +15,7 @@ class CloudEvent(PCBaseModel):
     source: str
     subject: Optional[str] = None
     id: str = Field(default_factory=lambda: uuid4().hex)
-    time: str = Field(default_factory=lambda: datetime.utcnow().isoformat())
+    time: str = Field(default_factory=lambda: tzutc_now().isoformat())
     data_content_type: str = Field(default="application/json", alias="datacontenttype")
     data: Union[Dict[str, Any], BaseModel]
 

--- a/pctasks/core/pctasks/core/models/record.py
+++ b/pctasks/core/pctasks/core/models/record.py
@@ -7,6 +7,7 @@ from pctasks.core.constants import RECORD_SCHEMA_VERSION
 from pctasks.core.models.base import PCBaseModel
 from pctasks.core.models.dataset import DatasetIdentifier
 from pctasks.core.models.event import CloudEvent
+from pctasks.core.models.utils import tzutc_now
 from pctasks.core.models.workflow import WorkflowConfig, WorkflowRunStatus
 from pctasks.core.tables.base import InvalidTableKeyError, validate_table_key
 from pctasks.core.utils import StrEnum
@@ -72,8 +73,8 @@ class WorkflowRunGroupStatus(StrEnum):
 
 class RunRecord(PCBaseModel):
     type: str
-    created: datetime = Field(default_factory=datetime.utcnow)
-    updated: datetime = Field(default_factory=datetime.utcnow)
+    created: datetime = Field(default_factory=tzutc_now)
+    updated: datetime = Field(default_factory=tzutc_now)
 
     errors: Optional[List[str]] = None
 
@@ -82,7 +83,7 @@ class RunRecord(PCBaseModel):
     schema_version: str = RECORD_SCHEMA_VERSION
 
     def set_update_time(self) -> None:
-        self.updated = datetime.utcnow()
+        self.updated = tzutc_now()
 
 
 class TaskRunRecord(RunRecord):
@@ -135,8 +136,8 @@ class WorkflowRunRecord(RunRecord):
     trigger_event: Optional[CloudEvent] = None
     args: Optional[Dict[str, Any]] = None
 
-    created: datetime = Field(default_factory=datetime.utcnow)
-    updated: datetime = Field(default_factory=datetime.utcnow)
+    created: datetime = Field(default_factory=tzutc_now)
+    updated: datetime = Field(default_factory=tzutc_now)
 
 
 class WorkflowRunGroupRecord(RunRecord):

--- a/pctasks/core/pctasks/core/models/task.py
+++ b/pctasks/core/pctasks/core/models/task.py
@@ -83,9 +83,7 @@ class TaskRunMessage(PCBaseModel):
     config: TaskRunConfig
 
     def encoded(self) -> str:
-        return b64encode(
-            self.json(exclude_unset=True, exclude_none=True).encode("utf-8")
-        ).decode("utf-8")
+        return b64encode(self.json(exclude_none=True).encode("utf-8")).decode("utf-8")
 
     @classmethod
     def decode(cls, msg_text: str) -> "TaskRunMessage":

--- a/pctasks/core/pctasks/core/models/utils.py
+++ b/pctasks/core/pctasks/core/models/utils.py
@@ -1,0 +1,9 @@
+from datetime import datetime
+
+from dateutil.tz import tzutc
+
+
+def tzutc_now() -> datetime:
+    """Consistent timezone-aware UTC timestamp for record models that are
+    serialized for API responses."""
+    return datetime.now(tzutc())

--- a/pctasks/core/pctasks/core/tables/base.py
+++ b/pctasks/core/pctasks/core/tables/base.py
@@ -35,9 +35,7 @@ class InvalidTableKeyError(Exception):
 
 
 def encode_model(m: BaseModel) -> str:
-    return b64encode(
-        m.json(exclude_unset=True, exclude_none=True).encode("utf-8")
-    ).decode("utf-8")
+    return b64encode(m.json(exclude_none=True).encode("utf-8")).decode("utf-8")
 
 
 def decode_dict(s: str) -> Dict[str, Any]:

--- a/pctasks/core/tests/models/test_task.py
+++ b/pctasks/core/tests/models/test_task.py
@@ -30,9 +30,7 @@ def test_serialize_task_run_msg():
         ),
     )
 
-    msg_text = b64encode(
-        msg.json(exclude_unset=True, exclude_none=True).encode("utf-8")
-    ).decode("utf-8")
+    msg_text = b64encode(msg.json(exclude_none=True).encode("utf-8")).decode("utf-8")
 
     msg_dict = json.loads(b64decode(msg_text.encode("utf-8")).decode("utf-8"))
     deserialized = TaskRunMessage.parse_obj(msg_dict)

--- a/pctasks/core/tests/tables/test_record.py
+++ b/pctasks/core/tests/tables/test_record.py
@@ -1,0 +1,39 @@
+from pctasks.core.models.dataset import DatasetIdentifier
+from pctasks.core.models.record import WorkflowRunRecord
+from pctasks.core.models.workflow import WorkflowConfig, WorkflowRunStatus
+from pctasks.core.tables.base import decode_dict, encode_model
+
+
+def test_encode_created():
+    workflow = """
+    name: Test workflow
+    dataset: microsoft/test-dataset
+
+    args:
+      - name
+
+    jobs:
+      test-job:
+        tasks:
+          - id: test-task
+            image_key: ingest-prod
+            task: tests.test_submit.MockTask
+            args:
+              hello: ${{ args.name }}
+    """
+    workflow = WorkflowConfig.from_yaml(workflow)
+    ds = DatasetIdentifier(name="test-dataset", owner="microsoft")
+    wr = WorkflowRunRecord(
+        status=WorkflowRunStatus.SUBMITTED,
+        workflow=workflow,
+        dataset=ds,
+        run_id="test-run",
+    )
+
+    assert wr.created is not None
+
+    encoded = encode_model(wr)
+    decoded = decode_dict(encoded)
+
+    assert "created" in decoded
+    assert decoded["created"] == wr.created.isoformat()

--- a/pctasks/operations/setup.py
+++ b/pctasks/operations/setup.py
@@ -6,7 +6,7 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    "pctasks-core>=0.1.0",
+    "pctasks.core>=0.1.0",
 ]
 
 extra_reqs = {


### PR DESCRIPTION
## Description

Fixes a few issues with the Records API
* `created` (or any model attribute with a default value) will be included in JSON serialized output
* Makes serializable dates in API responses time zone aware
* Fixes package name typo

Run record responses now look like this:

```
    {
      "links": null,
      "errors": null,
      "created": "2022-08-18T15:43:15.465446+00:00",
      "updated": "2022-08-18T15:43:30.503287+00:00",
      "status": "completed",
      "dataset": "microsoft/test-remote-1",
      "run_id": "1d8409a51631431daa3f145064d37561",
      "workflow": null,
      "trigger_event": null,
      "args": null
    },
```

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

New test + local testing

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)