### PR TITLE
fix: remove test_dataset expectation of workflow submit confirmation

### DIFF
--- a/pctasks/dev/pctasks/dev/test_utils.py
+++ b/pctasks/dev/pctasks/dev/test_utils.py
@@ -219,6 +219,7 @@ def run_workflow(
     )
     templated_workflow = template_workflow_dict(workflow.dict(), base_path=base_path)
     submit_settings = ClientSettings.get()
+    submit_settings.confirmation_required = False
     submit_message = PCTasksClient(submit_settings).submit_workflow(
         WorkflowSubmitMessage(workflow=templated_workflow, args=args)
     )


### PR DESCRIPTION
## Description

Integration test fails due to expectation of user confirmation of workflow submission. Run `./scripts/console integration-tests` and then `scripts/bin/test-integration` for failure.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Tests pass.

## Checklist:

- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)