### PR TITLE
ENH: Added TaskContext.run_id

### DIFF
--- a/datasets/deltaresfloods/tests/test_tasks.py
+++ b/datasets/deltaresfloods/tests/test_tasks.py
@@ -54,7 +54,7 @@ def test_create_chunks(dataset_config: DatasetConfig) -> None:
     )
 
     tokens = Tokens(collection_config.get_tokens())
-    context = TaskContext(StorageFactory(tokens=tokens))
+    context = TaskContext(StorageFactory(tokens=tokens), run_id="test-1")
 
     runner = SimpleWorkflowExecutor()
     result = runner.run_workflow(
@@ -76,7 +76,7 @@ def test_create_items(dataset_config: DatasetConfig) -> None:
 
     collection_config: CollectionConfig = dataset_config.collections[0]
     tokens = Tokens(collection_config.get_tokens())
-    context = TaskContext(StorageFactory(tokens=tokens))
+    context = TaskContext(StorageFactory(tokens=tokens), run_id="test-1")
 
     runner = SimpleWorkflowExecutor()
 

--- a/pctasks/dataset/tests/test_dataset.py
+++ b/pctasks/dataset/tests/test_dataset.py
@@ -56,7 +56,8 @@ def test_process_items() -> None:
                 output_uri=tmp_dir,
                 args={"test_prefix": path, "sas_token": get_azurite_sas_token()},
                 context=TaskContext(
-                    storage_factory=StorageFactory(tokens=Tokens(tokens))
+                    storage_factory=StorageFactory(tokens=Tokens(tokens)),
+                    run_id="test-dataset-1",
                 ),
             )
 

--- a/pctasks/dev/pctasks/dev/mocks.py
+++ b/pctasks/dev/pctasks/dev/mocks.py
@@ -12,9 +12,7 @@ class MockTaskContext(TaskContext):
 
     @classmethod
     def default(cls) -> "MockTaskContext":
-        return MockTaskContext(
-            storage_factory=StorageFactory(),
-        )
+        return MockTaskContext(storage_factory=StorageFactory(), run_id="run-id")
 
 
 class MockTaskInput(PCBaseModel):

--- a/pctasks/run/pctasks/run/_cli.py
+++ b/pctasks/run/pctasks/run/_cli.py
@@ -35,7 +35,7 @@ def local_cmd(workflow: str, args: List[str], output: Optional[str] = None) -> N
     runner = SimpleWorkflowExecutor()
     runner.run_workflow(
         workflow_config,
-        TaskContext(storage_factory=StorageFactory()),
+        TaskContext(storage_factory=StorageFactory(), run_id=workflow_config.name),
         args=workflow_args,
         output_uri=output,
     )

--- a/pctasks/run/pctasks/run/workflow/executor/simple.py
+++ b/pctasks/run/pctasks/run/workflow/executor/simple.py
@@ -181,7 +181,9 @@ class SimpleWorkflowExecutor:
                 pass
 
         if not context:
-            context = TaskContext(storage_factory=StorageFactory())
+            context = TaskContext(
+                storage_factory=StorageFactory(), run_id=workflow.name
+            )
 
         workflow_jobs = list(workflow.jobs.values())
         sorted_jobs = sort_jobs(workflow_jobs)

--- a/pctasks/task/pctasks/task/context.py
+++ b/pctasks/task/pctasks/task/context.py
@@ -8,9 +8,11 @@ from pctasks.core.tokens import Tokens
 @dataclass
 class TaskContext:
     storage_factory: StorageFactory
+    run_id: str
 
     @classmethod
     def from_task_run_config(cls, task_config: TaskRunConfig) -> "TaskContext":
         return cls(
             storage_factory=StorageFactory(Tokens(task_config.tokens)),
+            run_id=task_config.run_id,
         )


### PR DESCRIPTION
## Description

This adds a TaskContext.run_id field to the TaskContext class. This will
enable downstream tasks to include the run id in their logs / outputs.

Every `TaskContext` create through `task/run.py:run_task` has a pretty clear run ID. Some of the other ones just kind of have to be made up. I think that's fine for tests. I'm a bit worried about it for things like `SimpleWorkflowRunner` which, IIUC, don't have a natural run ID associated with them.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Not at all

## Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)