### PR TITLE
FIX: Added "pc" to rbac workflow namespaces

### DIFF
--- a/deployment/helm/argo-values.yaml
+++ b/deployment/helm/argo-values.yaml
@@ -3,3 +3,7 @@ server:
   secure: false
   # extraArgs:
   # - --auth-mode=server
+
+controller:
+  workflowNameSpaces:
+    - pc


### PR DESCRIPTION
This fixes the errors printed in the argo server

```
time="2022-08-30T12:40:35.432Z" level=warning msg="finished unary call with code PermissionDenied" error="rpc error: code = PermissionDenied desc = workflowtemplates.argoproj.io is forbidden: User \"system:serviceaccount:pc:pctasks-sa\" cannot list resource \"workflowtemplates\" in API group \"argoproj.io\" in the namespace \"pc\"" grpc.code=PermissionDenied grpc.method=ListWorkflowTemplates grpc.service=workflowtemplate.WorkflowTemplateService grpc.start_time="2022-08-30T12:40:35Z" grpc.time_ms=6.598 span.kind=server system=grpc
```

I tried to deploy this locally, but seemed to cause some issues along the lines of

```
  Warning  Failed     7m45s                   kubelet            Failed to pull image "quay.io/argoproj/argocli:v3.3.9": rpc error: code = Unknown desc = failed to pull and unpack image "quay.io/argoproj/argocli:v3.3.9": failed to resolve reference "quay.io/argoproj/argocli:v3.3.9": failed to do request: Head "https://quay.io/v2/argoproj/argocli/manifests/v3.3.9": dial tcp: lookup quay.io on [::1]:53: read udp [::1]:57912->[::1]:53: read: connection refused
```

I don't know if that's a local config issue or something that changed upstream.