### PR TITLE
Add command to clear development records.

### DIFF
--- a/pctasks/dev/pctasks/dev/cli.py
+++ b/pctasks/dev/pctasks/dev/cli.py
@@ -4,7 +4,7 @@ import sys
 from functools import lru_cache
 from typing import Any, Dict, List, Optional, Union
 
-from pctasks.dev.setup_azurite import setup_azurite
+from pctasks.dev.setup_azurite import setup_azurite, clear_records
 from pctasks.task.version import __version__
 
 logger = logging.getLogger(__name__)
@@ -29,6 +29,11 @@ def _setup_logging(level: Union[str, int], log_libraries: bool = False) -> None:
 
 def setup_azurite_cmd(args: Dict[str, Any]) -> int:
     setup_azurite()
+    return 0
+
+
+def clear_records_cmd(args: Dict[str, Any]) -> int:
+    clear_records()
     return 0
 
 
@@ -61,6 +66,14 @@ def parse_args(args: List[str]) -> Optional[Dict[str, Any]]:
         formatter_class=dhf,
     )
 
+    # clear-records command
+    _ = subparsers.add_parser(
+        "clear-records",
+        help="Clears Azurite records.",
+        parents=[parent],
+        formatter_class=dhf,
+    )
+
     parsed_args = {
         k: v for k, v in vars(parser0.parse_args(args)).items() if v is not None
     }
@@ -85,6 +98,8 @@ def cli(args: Optional[List[str]] = None) -> Optional[int]:
 
     if cmd == "setup-azurite":
         return setup_azurite_cmd(parsed_args)
+    if cmd == "clear-records":
+        return clear_records_cmd(parsed_args)
     return None
 
 

--- a/pctasks/dev/pctasks/dev/setup_azurite.py
+++ b/pctasks/dev/pctasks/dev/setup_azurite.py
@@ -108,5 +108,28 @@ def setup_azurite() -> None:
     print("~ Done Azurite setup.")
 
 
+def clear_records() -> None:
+    """Clears Azurite records from the tables.
+
+    Useful when there are changes to the Records models which make
+    existing dev records invalid.
+    """
+    table_service_client = TableServiceClient.from_connection_string(
+        get_azurite_connection_string()
+    )
+    tables = [t.name for t in table_service_client.list_tables()]
+    for table in [
+        DEFAULT_DATASET_TABLE_NAME,
+        DEFAULT_WORKFLOW_RUN_GROUP_RECORD_TABLE_NAME,
+        DEFAULT_WORKFLOW_RUN_RECORD_TABLE_NAME,
+        DEFAULT_JOB_RUN_RECORD_TABLE_NAME,
+        DEFAULT_TASK_RUN_RECORD_TABLE_NAME,
+    ]:
+        if table in tables:
+            print(f"~ ~ Clearing table {table}...")
+            table_service_client.delete_table(table)
+            table_service_client.create_table(table)
+
+
 if __name__ == "__main__":
     setup_azurite()

--- a/scripts/setup
+++ b/scripts/setup
@@ -17,6 +17,8 @@ Sets up this project for development.
 Options:
     --azurite
         Only run the Azurite setup.
+    --clear-records
+        Only clear the records tables from Azurite.
 "
 }
 
@@ -24,6 +26,10 @@ AZURITE_ONLY=""
 while [[ $# -gt 0 ]]; do case $1 in
     --azurite)
         AZURITE_ONLY=1
+        shift
+        ;;
+    --clear-records)
+        CLEAR_RECORDS=1
         shift
         ;;
     --help)
@@ -37,10 +43,18 @@ while [[ $# -gt 0 ]]; do case $1 in
         ;;
     esac done
 
-
 source scripts/env
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ "${CLEAR_RECORDS}" ]; then
+        echo "Clearing records from Azurite Tables..."
+        docker-compose -f docker-compose.console.yml run --rm \
+            dev \
+            pctasks-dev clear-records
+
+        echo "Records cleared."
+        exit 0;
+    fi
     if [ -z "${AZURITE_ONLY}" ]; then
 
         # Copy secrets template if it doesn't exist
@@ -48,7 +62,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             cp dev-secrets.template.yaml dev-secrets.yaml
         fi
 
-        setup_docker_network;
+        setup_docker_network
 
         echo " -- BUILDING CONTAINERS"
         scripts/update


### PR DESCRIPTION
This is useful if the schema of records changes without
backwards compatibility during development, and you
want to clear out invalid records without having to
clear your entire Azurite volume.
