### PR TITLE
Fix integration tests

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -30,16 +30,16 @@ jobs:
         uses: helm/kind-action@deab45fc8df9de5090a604e8ec11778eea7170bd
         with:
           install_only: true
-        if: github.base_ref  == 'refs/heads/master'
+        if: ${{ github.base_ref  == 'main' }}
 
       - name: Install Helm
         uses: azure/setup-helm@v1
-        if: github.base_ref  == 'refs/heads/master'
+        if: ${{ github.base_ref  == 'main' }}
 
       - name: Setup cluster
         run: ./scripts/cluster setup
-        if: github.base_ref  == 'refs/heads/master'
+        if: ${{ github.base_ref  == 'main' }}
 
       - name: Run integration tests
         run: ./scripts/citest-integration
-        if: github.base_ref  == 'refs/heads/master'
+        if: ${{ github.base_ref  == 'main' }}

--- a/cluster/dev-values.yaml
+++ b/cluster/dev-values.yaml
@@ -12,6 +12,7 @@ pctasks:
     dev:
       enabled: true
       api_key: "kind-api-key"
+      auth_token: "Bearer hunter2"
 
     image:
       repository: "localhost:5001/pctasks-server"

--- a/deployment/helm/published/pctasks-server/templates/deployment.yaml
+++ b/deployment/helm/published/pctasks-server/templates/deployment.yaml
@@ -54,6 +54,8 @@ spec:
               value: "{{ .Values.pctasks.server.dev.enabled }}"
             - name: PCTASKS_SERVER__DEV_API_KEY
               value: "{{ .Values.pctasks.server.dev.api_key }}"
+            - name: PCTASKS_SERVER__DEV_AUTH_TOKEN
+              value: "{{ .Values.pctasks.server.dev.auth_token }}"
             - name: PCTASKS_SERVER__RECORD_TABLES__CONNECTION_STRING
               value: "{{ .Values.pctasks.run.tables.connection_string }}"
 

--- a/deployment/helm/published/pctasks-server/values.yaml
+++ b/deployment/helm/published/pctasks-server/values.yaml
@@ -14,6 +14,7 @@ pctasks:
     dev:
       enabled: false
       api_key: ""
+      auth_token: ""
 
     image:
       # e.g. myacr.azurecr.io/my-repository


### PR DESCRIPTION
Fix an issue with a dev setting not being set in the Helm chart for pctasks-server, which was causing integration tests to fial.

Also fix typo in GH Actions workflow for PRs that was causing integration tests not to run on PRs against main.