### PR TITLE
Ensure 1 node for test

### DIFF
--- a/deployment/terraform/batch_pool/main.tf
+++ b/deployment/terraform/batch_pool/main.tf
@@ -37,7 +37,7 @@ resource "azurerm_batch_pool" "batch_pool" {
 
       minTargetDedicated = ${var.min_dedicated};
       maxTargetDedicated = ${var.max_dedicated};
-      minTargetLowPriority = ${var.min_low_priority};
+      minTargetLowPriority = ${var.min_tasks_low_priority};
       maxTargetLowPriority = ${var.max_low_priority};
 
       maxIncreasePerScale = ${var.max_increase_per_scale};

--- a/deployment/terraform/batch_pool/variables.tf
+++ b/deployment/terraform/batch_pool/variables.tf
@@ -34,7 +34,11 @@ variable "max_dedicated" {
   type = number
 }
 
-variable "min_low_priority" {
+variable "min_tasks_low_priority" {
+  type = number
+}
+
+variable "min_ingest_low_priority" {
   type = number
 }
 

--- a/deployment/terraform/dev/pools.tf
+++ b/deployment/terraform/dev/pools.tf
@@ -13,7 +13,7 @@ module "batch_pool_d3_v3" {
   min_dedicated = 0
   max_dedicated = 0
 
-  min_low_priority = var.min_low_priority
+  min_low_priority = var.min_tasks_low_priority
   max_low_priority = 50
 
   max_increase_per_scale = 50
@@ -38,7 +38,7 @@ module "batch_pool_d3_v3_ingest" {
   min_dedicated = 0
   max_dedicated = 0
 
-  min_low_priority = var.min_low_priority
+  min_low_priority = var.min_ingest_low_priority
   max_low_priority = 1
 
   max_increase_per_scale = 1

--- a/deployment/terraform/dev/variables.tf
+++ b/deployment/terraform/dev/variables.tf
@@ -17,11 +17,19 @@ variable "batch_default_pool_id" {
   default     = "tasks_pool"
 }
 
-variable "min_low_priority" {
+variable "min_tasks_low_priority" {
     type = number
     default = 0
-    description = "Minimum number of low priority Batch nodes to keep running"
+    description = "Minimum number of low priority Batch nodes to keep running in the tasks pool"
 }
+
+variable "min_ingest_low_priority" {
+    type = number
+    default = 0
+    description = "Minimum number of low priority Batch nodes to keep running in the ingest pool"
+}
+
+
 
 # ACR
 

--- a/deployment/terraform/staging/pools.tf
+++ b/deployment/terraform/staging/pools.tf
@@ -13,7 +13,7 @@ module "batch_pool_d3_v3" {
   min_dedicated = 0
   max_dedicated = 0
 
-  min_low_priority = var.min_low_priority
+  min_low_priority = var.min_tasks_low_priority
   max_low_priority = 50
 
   max_increase_per_scale = 50
@@ -38,7 +38,7 @@ module "batch_pool_d3_v3_ingest" {
   min_dedicated = 0
   max_dedicated = 0
 
-  min_low_priority = var.min_low_priority
+  min_low_priority = var.min_ingest_low_priority
   max_low_priority = 1
 
   max_increase_per_scale = 1

--- a/deployment/terraform/staging/variables.tf
+++ b/deployment/terraform/staging/variables.tf
@@ -17,11 +17,19 @@ variable "batch_default_pool_id" {
   default     = "tasks_pool"
 }
 
-variable "min_low_priority" {
+variable "min_tasks_low_priority" {
     type = number
     default = 0
-    description = "Minimum number of low priority Batch nodes to keep running"
+    description = "Minimum number of low priority Batch nodes to keep running in the tasks pool"
 }
+
+variable "min_ingest_low_priority" {
+    type = number
+    default = 0
+    description = "Minimum number of low priority Batch nodes to keep running in the ingest pool"
+}
+
+
 
 # ACR
 


### PR DESCRIPTION
## Description

This configures a minimum of one low priority node for pctasks-test, to speed up the feedback loop when developing / deploying a pipeline.

The `min_low_priority` terraform variable was used for two pools, "tasks" and "ingest". I've split that into two variables and left ingest at the previous default of 0.

I haven't tried deploying this yet.