### PR TITLE
Specify service account name

### DIFF
--- a/deployment/helm/argo-values.yaml
+++ b/deployment/helm/argo-values.yaml
@@ -3,3 +3,6 @@ server:
   secure: false
   # extraArgs:
   # - --auth-mode=server
+  serviceAccount:
+    name: pctasks-sa
+


### PR DESCRIPTION
## Description

Maybe fixes the Kubernetes RBAC issues we were seeing. The server is using a ServiceAcount `pctasks-sa`, but Helm / argo is creating a RoleBinding for the name `argo-workflows`. Maybe specifying it here will fix things?