### PR TITLE
Fix args argument for CLI run functions

### DIFF
--- a/pctasks/run/pctasks/run/_cli.py
+++ b/pctasks/run/pctasks/run/_cli.py
@@ -44,7 +44,7 @@ def local_cmd(workflow: str, args: List[str], output: Optional[str] = None) -> N
 def remote_cmd(
     ctx: click.Context,
     workflow: str,
-    arg: List[str],
+    args: List[str],
     new_id: bool,
     settings: Optional[str],
     sas: Optional[str],
@@ -65,12 +65,12 @@ def remote_cmd(
 
     # TODO: Do we need to pass in args at run time vs workflow submit msg?
     workflow_args: Optional[Dict[str, Any]] = None
-    if arg:
+    if args:
         workflow_args = {}
-        for a in arg:
+        for a in args:
             split_args = a.split("=")
             if not len(split_args) == 2:
-                raise click.UsageError(f"Invalid argument: {arg}")
+                raise click.UsageError(f"Invalid argument: {a}")
             workflow_args[split_args[0]] = split_args[1]
         submit_message.args = {**(submit_message.args or {}), **workflow_args}
 

--- a/pctasks/run/pctasks/run/cli.py
+++ b/pctasks/run/pctasks/run/cli.py
@@ -6,6 +6,7 @@ import click
 @click.command("local")
 @click.argument("workflow")
 @click.option(
+    "args",
     "-a",
     "--arg",
     multiple=True,
@@ -26,6 +27,7 @@ def local_cmd(workflow: str, args: List[str], output: Optional[str] = None) -> N
 @click.command("remote")
 @click.argument("workflow")
 @click.option(
+    "args",
     "-a",
     "--arg",
     multiple=True,
@@ -38,7 +40,7 @@ def local_cmd(workflow: str, args: List[str], output: Optional[str] = None) -> N
 def remote_cmd(
     ctx: click.Context,
     workflow: str,
-    arg: List[str],
+    args: List[str],
     new_id: bool,
     settings: Optional[str],
     sas: Optional[str],
@@ -46,7 +48,7 @@ def remote_cmd(
     """Execute a workflow using a remote runner."""
     from . import _cli
 
-    return _cli.remote_cmd(ctx, workflow, arg, new_id, settings, sas)
+    return _cli.remote_cmd(ctx, workflow, args, new_id, settings, sas)
 
 
 @click.group("run")


### PR DESCRIPTION
## Description

On **main**, the following command fails:

```sh
$ pctasks run local examples/list-logs.yaml

 ___   ___  _____            _
| _ \ / __||_   _| __ _  ___| |__ ___
|  _/| (__   | |  / _` |(_-/| / /(_-/
|_|   \___|  |_|  \__/_|/__/|_\_\/__/

Traceback (most recent call last):
  File "/Users/gadomski/.virtualenvs/planetary-computer-tasks/bin/pctasks", line 33, in <module>
    sys.exit(load_entry_point('pctasks.cli', 'console_scripts', 'pctasks')())
  File "/Users/gadomski/Code/planetary-computer-tasks/pctasks/cli/pctasks/cli/cli.py", line 134, in cli
    pctasks_cmd(prog_name="pctasks")
  File "/Users/gadomski/.virtualenvs/planetary-computer-tasks/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "/Users/gadomski/.virtualenvs/planetary-computer-tasks/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "/Users/gadomski/.virtualenvs/planetary-computer-tasks/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/gadomski/.virtualenvs/planetary-computer-tasks/lib/python3.10/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/gadomski/.virtualenvs/planetary-computer-tasks/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/gadomski/.virtualenvs/planetary-computer-tasks/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
TypeError: local_cmd() got an unexpected keyword argument 'arg'
```

This PR fixes the issue, and also updates the `remote` command argument name to `args` as well (which makes more sense to me since there's many arguments).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Manually, since there didn't appear to be any CLI tests for the `pctasks.run` module.

```sh
$ pctasks run local examples/list-logs.yaml

 ___   ___  _____            _
| _ \ / __||_   _| __ _  ___| |__ ___
|  _/| (__   | |  / _` |(_-/| / /(_-/
|_|   \___|  |_|  \__/_|/__/|_\_\/__/

[INFO]:2022-09-16 13:46:12,767:  === PCTasks (simple workflow runner) ===
[INFO]:2022-09-16 13:46:12,778:   -- PCTasks: Running task...
... snip ...
```

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)