### PR TITLE
Adjust node count on AKS cluster

### DIFF
--- a/deployment/terraform/staging/main.tf
+++ b/deployment/terraform/staging/main.tf
@@ -44,6 +44,6 @@ module "resources" {
 
   cluster_cert_issuer = "letsencrypt"
   cluster_cert_server = "https://acme-v02.api.letsencrypt.org/directory"
-  aks_node_count = 1
+  aks_node_count = 2
   pctasks_server_replica_count = 1
 }


### PR DESCRIPTION
The AKS cluster that's deployed as part of CI/CD was manually change to have 2 nodes. Previous terraform deploys have failed due to an inability to drain those nodes. Bumping the terraform up to 2 nodes, which can be moved back down to 1 if need be after the problem node is manually debugged. 