### PR TITLE
Fix docs, it's `records status`, not `records show`

### DIFF
--- a/docs/getting_started/dev_workflows.md
+++ b/docs/getting_started/dev_workflows.md
@@ -91,7 +91,7 @@ If you experience issues with the above step, take a look at some of these commo
 Using the run ID from the previous step, you can watch the execution status of the workflow using:
 
 ```shell
-> pctasks records show workflow --watch ${RUN_ID}
+> pctasks records status workflow --watch ${RUN_ID}
 ```
 
 This may return instantly, since the workflow should run quickly. However you can use this command with the `--watch` option to poll the API for status and update the console until the job completes.


### PR DESCRIPTION
## Description

Small docs fix.

## Type of change

- [x] This change requires a documentation update

## How Has This Been Tested?

Manually:

```sh
$ pctasks records status workflow --watch b948177655b94ce7a3ab4b5f484a0bae

 ___   ___  _____            _
| _ \ / __||_   _| __ _  ___| |__ ___
|  _/| (__   | |  / _` |(_-/| / /(_-/
|_|   \___|  |_|  \__/_|/__/|_\_\/__/

┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━┓
┃                                     ┃ status          ┃
┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━┩
│ Workflow: List log files in Azurite │ 🏃 Running      │
│  - Job: list-logs-job               │  🏃 Running     │
│     - Task:list-logs-task           │   🕖 Submitting │
└─────────────────────────────────────┴─────────────────┘
```

## Checklist:

Please delete options that are not relevant.

- [x] Documentation has been updated
- [x] Code is linted and styled (./scripts/format)