### PR TITLE
Add option to not flatten foreach lists

### DIFF
--- a/pctasks/core/pctasks/core/models/base.py
+++ b/pctasks/core/pctasks/core/models/base.py
@@ -105,5 +105,6 @@ class ForeachConfig(PCBaseModel):
     flatten: bool, default True
         Whether to flatten lists nested objects to a single flat list.
     """
+
     items: Union[str, List[Any]]
     flatten: bool = True

--- a/pctasks/core/pctasks/core/models/base.py
+++ b/pctasks/core/pctasks/core/models/base.py
@@ -96,4 +96,14 @@ class RunRecordId(PCBaseModel):
 
 
 class ForeachConfig(PCBaseModel):
+    """
+    Configuration for foreach blocks in workflows.
+
+    Parameters
+    ----------
+    items: string or list of objects
+    flatten: bool, default True
+        Whether to flatten lists nested objects to a single flat list.
+    """
     items: Union[str, List[Any]]
+    flatten: bool = True

--- a/pctasks/run/pctasks/run/template.py
+++ b/pctasks/run/pctasks/run/template.py
@@ -69,8 +69,8 @@ def template_foreach(
     if not isinstance(items, list):
         raise TemplateError(f"foreach expected list of items, got {items}")
 
-    if foreach.flatten:
-        items = completely_flatten(items)
+    # if foreach.flatten:
+    #     items = completely_flatten(items)
     items = list(items)
     return items
 

--- a/pctasks/run/pctasks/run/template.py
+++ b/pctasks/run/pctasks/run/template.py
@@ -69,8 +69,8 @@ def template_foreach(
     if not isinstance(items, list):
         raise TemplateError(f"foreach expected list of items, got {items}")
 
-    # if foreach.flatten:
-    #     items = completely_flatten(items)
+    if foreach.flatten:
+        items = completely_flatten(items)
     items = list(items)
     return items
 

--- a/pctasks/run/pctasks/run/template.py
+++ b/pctasks/run/pctasks/run/template.py
@@ -70,9 +70,9 @@ def template_foreach(
         raise TemplateError(f"foreach expected list of items, got {items}")
 
     if foreach.flatten:
-        items = completely_flatten(items)
-    items = list(items)
-    return items
+        return list(completely_flatten(items))
+    else:
+        return list(items)
 
 
 class ItemTemplater(Templater):

--- a/pctasks/run/pctasks/run/template.py
+++ b/pctasks/run/pctasks/run/template.py
@@ -69,7 +69,10 @@ def template_foreach(
     if not isinstance(items, list):
         raise TemplateError(f"foreach expected list of items, got {items}")
 
-    return list(completely_flatten(items))
+    if foreach.flatten:
+        items = completely_flatten(items)
+    items = list(items)
+    return items
 
 
 class ItemTemplater(Templater):

--- a/pctasks/run/tests/test_template.py
+++ b/pctasks/run/tests/test_template.py
@@ -43,8 +43,7 @@ def test_template_foreach_multilevel():
 
 def test_template_foreach_nested():
     foreach_config = ForeachConfig(
-        items="${{ jobs.job1.tasks.task1.output.items }}",
-        flatten=False
+        items="${{ jobs.job1.tasks.task1.output.items }}", flatten=False
     )
     jobs_output: Dict[str, Union[Dict[str, Any], List[Dict[str, Any]]]] = {
         "job1": [

--- a/pctasks/run/tests/test_template.py
+++ b/pctasks/run/tests/test_template.py
@@ -39,3 +39,19 @@ def test_template_foreach_multilevel():
 
     templated = template_foreach(foreach_config, jobs_output, None)
     assert templated == ["one", "two", "three"]
+
+
+def test_template_foreach_nested():
+    foreach_config = ForeachConfig(
+        items="${{ jobs.job1.tasks.task1.output.items }}",
+        flatten=False
+    )
+    jobs_output: Dict[str, Union[Dict[str, Any], List[Dict[str, Any]]]] = {
+        "job1": [
+            {"tasks": {"task1": {"output": {"items": ["a", "b"]}}}},
+            {"tasks": {"task1": {"output": {"items": ["c", "d"]}}}},
+        ]
+    }
+
+    templated = template_foreach(foreach_config, jobs_output, None)
+    assert templated == [["a", "b"], ["c", "d"]]


### PR DESCRIPTION
## Description

This adds a configuration option to `ForEachConfig` to optionally not flatten lists of lists. The default (True) preserves the existing behavior.

My use-case is an upstream task returning a `list[tuple[start, end]]`. The downstream uses a foreach to parallelize over this list, and each task needs the `(start, end)` tuple to work on the correct subset of the items.