### PR TITLE
[core]: relax pin on stac-validator

### DIFF
--- a/pctasks/core/setup.py
+++ b/pctasks/core/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     "pydantic>=1.9,<2.0.0",
     "orjson==3.*",
     "strictyaml>=1.6",
-    "stac-validator==3.1.*",
+    "stac-validator>=3.1.*",
     "opencensus-ext-azure==1.1.0",
     "opencensus-ext-logging==0.1.1",
     "pyyaml>=5.3",


### PR DESCRIPTION
## Description

Relaxes the pin on stac-validator, to make it possible to solve in an environment with stactools / stac-check. xref https://github.com/stac-utils/stac-check/issues/88, which discusses the pin in stac-check to 3.2.0.