### PR TITLE
[client]: Avoid redirects when listing jobs, tasks

### DIFF
--- a/pctasks/client/pctasks/client/client.py
+++ b/pctasks/client/pctasks/client/client.py
@@ -42,9 +42,9 @@ UPLOAD_CODE_ROUTE = "code/upload/"
 # Records
 LIST_RUNS_ROUTE = "runs/"
 FETCH_RUN_ROUTE = "runs/{run_id}"
-LIST_JOBS_ROUTE = "runs/{run_id}/jobs/"
+LIST_JOBS_ROUTE = "runs/{run_id}/jobs"
 FETCH_JOB_ROUTE = "runs/{run_id}/jobs/{job_id}"
-LIST_TASKS_ROUTE = "runs/{run_id}/jobs/{job_id}/tasks/"
+LIST_TASKS_ROUTE = "runs/{run_id}/jobs/{job_id}/tasks"
 FETCH_TASK_ROUTE = "runs/{run_id}/jobs/{job_id}/tasks/{task_id}"
 
 


### PR DESCRIPTION
## Description

Cuts out a redirect from, e.g. `tasks/` to `tasks` that I spotted in the logs:

```
132729:INFO:     20.76.197.174:0 - "GET /tasks/runs/50a89bd6eab948f0bcd1e17938c36086/jobs/copy%5B0%5D/tasks/ HTTP/1.1" 307 Temporary Redirect
132730:INFO:     20.76.197.174:0 - "GET /tasks/runs/50a89bd6eab948f0bcd1e17938c36086/jobs/copy%5B0%5D/tasks HTTP/1.1" 200 OK
```
