### PR TITLE
[client]: Wrap client API requests in with_backoff

### DIFF
--- a/pctasks/client/pctasks/client/client.py
+++ b/pctasks/client/pctasks/client/client.py
@@ -5,7 +5,6 @@ import pathlib
 import zipfile
 from time import perf_counter
 from typing import Any, Dict, List, Optional, Union
-from pctasks.core.utils.backoff import with_backoff
 
 import requests
 from requests import HTTPError
@@ -33,6 +32,7 @@ from pctasks.core.models.workflow import (
     WorkflowSubmitMessage,
     WorkflowSubmitResult,
 )
+from pctasks.core.utils.backoff import with_backoff
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Description

I spotted a 503 error when polling the task status endpoint with my client:

```pytb
  File "/opt/hostedtoolcache/Python/3.9.14/x64/lib/python3.9/site-packages/pctasks/client/records/commands/status.py", line 30, in fetch_workflow_cmd
    ctx.exit(_status.workflow_status_cmd(ctx, run_id, dataset, watch))
  File "/opt/hostedtoolcache/Python/3.9.14/x64/lib/python3.9/site-packages/pctasks/client/records/commands/_status.py", line 73, in workflow_status_cmd
    table, is_complete = get_table()
  File "/opt/hostedtoolcache/Python/3.9.14/x64/lib/python3.9/site-packages/pctasks/client/records/commands/_status.py", line 46, in get_table
    for job in sorted(client.get_jobs(run_id), key=lambda j: j.created):
  File "/opt/hostedtoolcache/Python/3.9.14/x64/lib/python3.9/site-packages/pctasks/client/client.py", line 207, in get_jobs
    result = self._call_api("GET", route)
  File "/opt/hostedtoolcache/Python/3.9.14/x64/lib/python3.9/site-packages/pctasks/client/client.py", line 75, in _call_api
    resp.raise_for_status()
  File "/opt/hostedtoolcache/Python/3.9.14/x64/lib/python3.9/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 503 Server Error: Service Temporarily Unavailable for url: https://pctaskstest-staging.azure-api.net/tasks/runs/50a89bd6eab948f0bcd1e17938c36086/jobs/
```

I haven't determined the cause of the 503 error. But since 503 is one of the error codes we retry on with `with_backoff`, we should be able to handle it and retry.