### PR TITLE
Fix batch task IDs, allow skipping jobs with no partitions

### DIFF
--- a/datasets/chesapeake_lulc/dataset.yaml
+++ b/datasets/chesapeake_lulc/dataset.yaml
@@ -1,4 +1,4 @@
-name: chesapeake_lulc
+id: chesapeake_lulc
 image: ${{ args.registry }}/pctasks-task-base:latest
 
 args:

--- a/datasets/deltaresfloods/dataset.yaml
+++ b/datasets/deltaresfloods/dataset.yaml
@@ -1,4 +1,4 @@
-name: deltaresfloods
+id: deltaresfloods
 image: pccomponentstest.azurecr.io/pctasks-basic:2022.6.16.2
 target_environment: staging
 environment:

--- a/datasets/io-land-cover/dataset.yaml
+++ b/datasets/io-land-cover/dataset.yaml
@@ -1,4 +1,4 @@
-name: io_lulc
+id: io_lulc
 image: ${{ args.registry }}/pctasks-task-base:latest
 
 args:

--- a/datasets/noaa_nclimgrid/dataset.yaml
+++ b/datasets/noaa_nclimgrid/dataset.yaml
@@ -1,4 +1,4 @@
-name: noaa_nclimgrid
+id: noaa_nclimgrid
 image: ${{ args.registry }}/pctasks-task-base:latest
 
 args:
@@ -8,7 +8,7 @@ code:
   src: ${{ local.path(./noaa_nclimgrid.py) }}
   requirements: ${{ local.path(./requirements.txt) }}
 
-environment: 
+environment:
   AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
   AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
   AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}

--- a/datasets/sentinel-1-grd/dataset.yaml
+++ b/datasets/sentinel-1-grd/dataset.yaml
@@ -1,4 +1,4 @@
-name: sentinel-1-grd
+id: sentinel-1-grd
 collections:
   id: sentinel-1-grd
   containers:

--- a/datasets/sentinel-3/dataset.yaml
+++ b/datasets/sentinel-3/dataset.yaml
@@ -1,4 +1,4 @@
-name: sentinel-1-grd
+id: sentinel-1-grd
 collections:
   id: sentinel-1-grd
   containers:

--- a/datasets/sentinel-5p/dataset.yaml
+++ b/datasets/sentinel-5p/dataset.yaml
@@ -1,4 +1,4 @@
-name: sentinel-1-grd
+id: sentinel-1-grd
 collections:
   id: sentinel-1-grd
   containers:

--- a/pctasks/client/pctasks/client/runs/_status.py
+++ b/pctasks/client/pctasks/client/runs/_status.py
@@ -47,10 +47,12 @@ def workflow_status_cmd(ctx: click.Context, run_id: str, watch: bool = False) ->
                 return 1
             if job_status == JobRunStatus.PENDING:
                 return 2
-            if job_status == JobRunStatus.RUNNING:
+            if job_status == JobRunStatus.COMPLETED:
                 return 3
-            else:
+            if job_status == JobRunStatus.SKIPPED:
                 return 4
+            else:
+                return 5
 
         for job in sorted(workflow.jobs, key=lambda x: _job_status_sort(x.status)):
             _table.add_row(

--- a/pctasks/client/pctasks/client/utils.py
+++ b/pctasks/client/pctasks/client/utils.py
@@ -7,5 +7,7 @@ def status_emoji(status: str) -> str:
         return "🏃"
     if status.lower() == "cancelled":
         return "🚫"
+    if status.lower() == "skipped":
+        return "⏭️"
     else:
         return "🕖"

--- a/pctasks/core/pctasks/core/models/run.py
+++ b/pctasks/core/pctasks/core/models/run.py
@@ -74,6 +74,7 @@ class JobRunStatus(StrEnum):
     RUNNING = "running"
     COMPLETED = "completed"
     FAILED = "failed"
+    SKIPPED = "skipped"
     CANCELLED = "cancelled"
     PENDING = "pending"
 

--- a/pctasks/run/pctasks/run/workflow/executor/remote.py
+++ b/pctasks/run/pctasks/run/workflow/executor/remote.py
@@ -700,7 +700,7 @@ class RemoteWorkflowExecutor:
                             JobRunStatus.SKIPPED,
                             job_run.add_errors(
                                 [f"Job {job_def.id} has no partitions to run."]
-                            )
+                            ),
                         )
                         continue
 
@@ -918,9 +918,7 @@ class RemoteWorkflowExecutor:
                         workflow_failed = True
                     else:
                         if len(job_results) == 1:
-                            job_outputs[job_id] = {
-                                TASKS_TEMPLATE_PATH: job_results[0]
-                            }
+                            job_outputs[job_id] = {TASKS_TEMPLATE_PATH: job_results[0]}
                         else:
                             job_output_entry: List[Dict[str, Any]] = []
                             for job_result in job_results:

--- a/pctasks/run/pctasks/run/workflow/executor/remote.py
+++ b/pctasks/run/pctasks/run/workflow/executor/remote.py
@@ -698,9 +698,7 @@ class RemoteWorkflowExecutor:
                             workflow_run,
                             job_def.get_id(),
                             JobRunStatus.SKIPPED,
-                            job_run.add_errors(
-                                [f"Job {job_def.id} has no partitions to run."]
-                            ),
+                            errors=[f"Job {job_def.id} has no partitions to run."],
                         )
                         continue
 

--- a/scripts/publish
+++ b/scripts/publish
@@ -20,6 +20,7 @@ IMAGE_TAG - The tag to use for all images.
 
 options:
   --no-login     Don't attempt log into the ACR using the azure cli.
+  --only IMAGE   Only publish the specified image.
 "
 }
 
@@ -38,6 +39,11 @@ while [[ "$#" -gt 0 ]]; do case $1 in
         ;;
     --no-login)
         NO_LOGIN="1"
+        shift
+        ;;
+    --only)
+        ONLY_IMAGE=$2
+        shift
         shift
         ;;
     --help)
@@ -69,10 +75,14 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
             az acr login -n ${ACR_NAME}
         fi
 
-        publish pctasks-ingest
-        publish pctasks-server
-        publish pctasks-run
-        publish pctasks-task-base
+        if [ "${ONLY_IMAGE}" ]; then
+            publish ${ONLY_IMAGE}
+        else
+            publish pctasks-ingest
+            publish pctasks-server
+            publish pctasks-run
+            publish pctasks-task-base
+        fi
 
     fi
 


### PR DESCRIPTION
This is a follow up to #54 which fixes an issue where batch tasks did not include the job partition ID, which was breaking fan-out. It also improves the ability to handle initial task submission failures, and introduces a "skipped" job status which occurs if there are no partitions to run, and does not fail the workflow.