### PR TITLE
[client]: retry on 503 errors

### DIFF
--- a/pctasks/core/pctasks/core/utils/backoff.py
+++ b/pctasks/core/pctasks/core/utils/backoff.py
@@ -57,7 +57,7 @@ def get_exception_status_code(e: Exception) -> Optional[int]:
 
 def is_common_throttle_exception(e: Exception) -> bool:
     status_code = get_exception_status_code(e)
-    if status_code is not None and (status_code == 503 or status_code == 429):
+    if status_code is not None and status_code in (502, 503, 429):
         return True
 
     if "connection reset by peer" in str(e).lower():

--- a/pctasks/core/tests/utils/test_utils.py
+++ b/pctasks/core/tests/utils/test_utils.py
@@ -1,4 +1,10 @@
+import unittest.mock
+
+import pytest
+import requests
+
 from pctasks.core.utils import completely_flatten
+from pctasks.core.utils.backoff import BackoffError, with_backoff
 
 
 def test_completely_flatten():
@@ -6,3 +12,17 @@ def test_completely_flatten():
     assert list(completely_flatten([1, 2, 3])) == [1, 2, 3]
     assert list(completely_flatten([1, [2, 3], 4])) == [1, 2, 3, 4]
     assert list(completely_flatten([1, [2, [3, 4]], 5])) == [1, 2, 3, 4, 5]
+
+
+def test_backoff():
+    def f():
+        request = requests.Request()
+        response = requests.Response()
+        response.request = request
+        response.status_code = 502
+        raise requests.HTTPError("502 Error", request=request, response=response)
+
+    # Mock time.sleep to keep the test fast
+    with unittest.mock.patch("pctasks.core.utils.backoff.time.sleep"):
+        with pytest.raises(BackoffError):
+            with_backoff(f)


### PR DESCRIPTION
While running tests locally, I noticed kubernetes killing the server pod

```
❯ kubectl -n pc get events | grep -i kil
26s         Normal    Killing             pod/pctasks-server-6f9fc7dd45-tdqds                      Container pctasks-server failed liveness probe, will be restarted
12m         Normal    Killing             pod/pctasks-server-78d5997f66-lc5js                      Container pctasks-server failed liveness probe, will be restarted
```

This, in turn, failed the tests when it attempted to make an HTTP request to the server:

```
        if http_error_msg:
>           raise HTTPError(http_error_msg, response=self)
E           requests.exceptions.HTTPError: 502 Server Error: Bad Gateway for url: http://host.docker.internal:8500/tasks/runs/33de2707-f2ed-40c9-a4ac-162d67658d9f
```

I don't know why the server was unresponsive and getting killed. But our client should probably be robust to this failure by retrying 502 errors.

## How Has This Been Tested?

See `pctasks/core/tests/utils/test_utils.py`

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)