### PR TITLE
datetime and qpe extension schema updates

### DIFF
--- a/datasets/noaa-mrms-qpe/collection/noaa-mrms-qpe-1h-pass1/template.json
+++ b/datasets/noaa-mrms-qpe/collection/noaa-mrms-qpe-1h-pass1/template.json
@@ -27,7 +27,8 @@
     ],
     "stac_extensions": [
         "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
-        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/noaa-mrms-qpe/v1.0.0/schema.json"
     ],
     "keywords": [
         "NOAA",

--- a/datasets/noaa-mrms-qpe/collection/noaa-mrms-qpe-1h-pass2/template.json
+++ b/datasets/noaa-mrms-qpe/collection/noaa-mrms-qpe-1h-pass2/template.json
@@ -27,7 +27,8 @@
     ],
     "stac_extensions": [
         "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
-        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/noaa-mrms-qpe/v1.0.0/schema.json"
     ],
     "keywords": [
         "NOAA",

--- a/datasets/noaa-mrms-qpe/collection/noaa-mrms-qpe-24h-pass2/template.json
+++ b/datasets/noaa-mrms-qpe/collection/noaa-mrms-qpe-24h-pass2/template.json
@@ -27,7 +27,8 @@
     ],
     "stac_extensions": [
         "https://stac-extensions.github.io/raster/v1.1.0/schema.json",
-        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json"
+        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/noaa-mrms-qpe/v1.0.0/schema.json"
     ],
     "keywords": [
         "NOAA",

--- a/datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
+++ b/datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
@@ -40,13 +40,6 @@ class NoaaMrmsQpeCollection(Collection):
             # temporary grammar fix
             item.assets["cog"].title = "Processed Cloud Optimized GeoTIFF file"
 
-            # custom extension schema points to the main branch, which could change
-            schema = (
-                "https://raw.githubusercontent.com/stactools-packages/"
-                "noaa-mrms-qpe/main/extension/schema.json"
-            )
-            item.stac_extensions.remove(schema)
-
             # upload cog to Azure
             cog_storage = storage_factory.get_storage(f"{COG_CONTAINER}/{path_fragment}/")
             cog_filename = meta.id + ".tif"

--- a/datasets/noaa-mrms-qpe/requirements.txt
+++ b/datasets/noaa-mrms-qpe/requirements.txt
@@ -1,1 +1,1 @@
-stactools-noaa-mrms-qpe == 0.2.0
+git+https://github.com/stactools-packages/noaa-mrms-qpe.git@38b86ba2570f08e0c81f522aa2d44201d24fbce1


### PR DESCRIPTION
- pin to latest qpe stactools commit
- no longer remove custom qpe schema
- update collection templates with new custom qpe schema url

## Description

Incorporate qpe stactools package datetime bugfix and the relocation of the custom qpe schema to its own repository.
- pin to latest qpe stactools commit
- no longer remove custom qpe schema from Items
- update collection templates with new custom qpe schema URL in `stac_extensions` list.

The collection template updates mean the collections will need to be re-ingested. 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Not tested yet

## Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)