### PR TITLE
[noaa-nclimgrid]: Drop source NetCDF assets

### DIFF
--- a/datasets/noaa_nclimgrid/collection/noaa-nclimgrid-daily-prelim/template.json
+++ b/datasets/noaa_nclimgrid/collection/noaa-nclimgrid-daily-prelim/template.json
@@ -164,38 +164,6 @@
                     "spatial_resolution": 5000
                 }
             ]
-        },
-        "prcp_source": {
-            "type": "application/netcdf",
-            "roles": [
-                "data",
-                "source"
-            ],
-            "title": "Daily Precipitation Source Data"
-        },
-        "tavg_source": {
-            "type": "application/netcdf",
-            "roles": [
-                "data",
-                "source"
-            ],
-            "title": "Daily Average Temperature Source Data"
-        },
-        "tmax_source": {
-            "type": "application/netcdf",
-            "roles": [
-                "data",
-                "source"
-            ],
-            "title": "Daily Maximmum Temperature Source Data"
-        },
-        "tmin_source": {
-            "type": "application/netcdf",
-            "roles": [
-                "data",
-                "source"
-            ],
-            "title": "Daily Minimum Temperature Source Data"
         }
     }
 }

--- a/datasets/noaa_nclimgrid/collection/noaa-nclimgrid-daily-scaled/template.json
+++ b/datasets/noaa_nclimgrid/collection/noaa-nclimgrid-daily-scaled/template.json
@@ -164,38 +164,6 @@
                     "spatial_resolution": 5000
                 }
             ]
-        },
-        "prcp_source": {
-            "type": "application/netcdf",
-            "roles": [
-                "data",
-                "source"
-            ],
-            "title": "Daily Precipitation Source Data"
-        },
-        "tavg_source": {
-            "type": "application/netcdf",
-            "roles": [
-                "data",
-                "source"
-            ],
-            "title": "Daily Average Temperature Source Data"
-        },
-        "tmax_source": {
-            "type": "application/netcdf",
-            "roles": [
-                "data",
-                "source"
-            ],
-            "title": "Daily Maximmum Temperature Source Data"
-        },
-        "tmin_source": {
-            "type": "application/netcdf",
-            "roles": [
-                "data",
-                "source"
-            ],
-            "title": "Daily Minimum Temperature Source Data"
         }
     }
 }

--- a/datasets/noaa_nclimgrid/collection/noaa-nclimgrid-monthly/description.md
+++ b/datasets/noaa_nclimgrid/collection/noaa-nclimgrid-monthly/description.md
@@ -6,3 +6,5 @@ This Collection contains **Monthly** data. See the journal publication ["Improve
 
 Users of all NClimGrid data product should be aware that [NOAA advertises](https://www.ncei.noaa.gov/access/metadata/landing-page/bin/iso?id=gov.noaa.ncdc:C00332) that:
 >"On an annual basis, approximately one year of 'final' NClimGrid data is submitted to replace the initially supplied 'preliminary' data for the same time period. Users should be sure to ascertain which level of data is required for their research."
+
+*Note: The Planetary Computer currently contains STAC metadata for just the monthly collection. We'll have STAC metadata for daily data in our next release. In the meantime, you can access the daily NetCDF data directly from Blob Storage using the storage container at `https://nclimgridwesteurope.blob.core.windows.net/nclimgrid`. See https://planetarycomputer.microsoft.com/docs/concepts/data-catalog/#access-patterns for more.*

--- a/datasets/noaa_nclimgrid/collection/noaa-nclimgrid-monthly/description.md
+++ b/datasets/noaa_nclimgrid/collection/noaa-nclimgrid-monthly/description.md
@@ -7,4 +7,6 @@ This Collection contains **Monthly** data. See the journal publication ["Improve
 Users of all NClimGrid data product should be aware that [NOAA advertises](https://www.ncei.noaa.gov/access/metadata/landing-page/bin/iso?id=gov.noaa.ncdc:C00332) that:
 >"On an annual basis, approximately one year of 'final' NClimGrid data is submitted to replace the initially supplied 'preliminary' data for the same time period. Users should be sure to ascertain which level of data is required for their research."
 
-*Note: The Planetary Computer currently contains STAC metadata for just the monthly collection. We'll have STAC metadata for daily data in our next release. In the meantime, you can access the daily NetCDF data directly from Blob Storage using the storage container at `https://nclimgridwesteurope.blob.core.windows.net/nclimgrid`. See https://planetarycomputer.microsoft.com/docs/concepts/data-catalog/#access-patterns for more.*
+The source NetCDF files are delivered to Azure as part of the [NOAA Open Data Dissemination (NODD) Program](https://www.noaa.gov/information-technology/open-data-dissemination).
+
+*Note*: The Planetary Computer currently has STAC metadata for just the monthly collection. We'll have STAC metadata for daily data in our next release. In the meantime, you can access the daily NetCDF data directly from Blob Storage using the storage container at `https://nclimgridwesteurope.blob.core.windows.net/nclimgrid`. See https://planetarycomputer.microsoft.com/docs/concepts/data-catalog/#access-patterns for more.*

--- a/datasets/noaa_nclimgrid/collection/noaa-nclimgrid-monthly/template.json
+++ b/datasets/noaa_nclimgrid/collection/noaa-nclimgrid-monthly/template.json
@@ -165,38 +165,6 @@
                     "spatial_resolution": 5000
                 }
             ]
-        },
-        "prcp_source": {
-            "type": "application/netcdf",
-            "roles": [
-                "data",
-                "source"
-            ],
-            "title": "Monthly Precipitation Source Data"
-        },
-        "tavg_source": {
-            "type": "application/netcdf",
-            "roles": [
-                "data",
-                "source"
-            ],
-            "title": "Monthly Average Temperature Source Data"
-        },
-        "tmax_source": {
-            "type": "application/netcdf",
-            "roles": [
-                "data",
-                "source"
-            ],
-            "title": "Monthly Maximmum Temperature Source Data"
-        },
-        "tmin_source": {
-            "type": "application/netcdf",
-            "roles": [
-                "data",
-                "source"
-            ],
-            "title": "Monthly Minimum Temperature Source Data"
         }
     },
     "sci:doi": "10.7289/V5SX6B56",

--- a/datasets/noaa_nclimgrid/noaa_nclimgrid.py
+++ b/datasets/noaa_nclimgrid/noaa_nclimgrid.py
@@ -41,7 +41,9 @@ class NoaaNclimgridCollection(Collection):
                 all_nc_urls[var] = nc_storage.get_url(nc_path)
 
             # create items and cogs
-            items, _ = create_items(tmp_nc_path, tmp_cog_dir, nc_assets=True)
+            # explicitly do *not* include the source NetCDF assets.
+            # We'll include those in a separate collection later and link to them.
+            items, _ = create_items(tmp_nc_path, tmp_cog_dir, nc_assets=False)
 
             local_cogs = {f.name: f.as_posix() for f in tmp_cog_dir.glob("*.tif")}
             if len(local_cogs) != len(items) * 4:
@@ -61,8 +63,5 @@ class NoaaNclimgridCollection(Collection):
                     cog_storage.upload_file(local_cogs[cog_filename], cog_filename)
 
                     item.assets[var].href = cog_storage.get_url(cog_filename)
-                    # preference: drop the reference to the source NetCDF
-                    # TODO: Add source NetCDF collections and link with via
-                    item.assets.pop(f"{var}_source", None)
 
         return items

--- a/datasets/noaa_nclimgrid/noaa_nclimgrid.py
+++ b/datasets/noaa_nclimgrid/noaa_nclimgrid.py
@@ -61,6 +61,8 @@ class NoaaNclimgridCollection(Collection):
                     cog_storage.upload_file(local_cogs[cog_filename], cog_filename)
 
                     item.assets[var].href = cog_storage.get_url(cog_filename)
-                    item.assets[f"{var}_source"].href = all_nc_urls[var]
+                    # preference: drop the reference to the source NetCDF
+                    # TODO: Add source NetCDF collections and link with via
+                    item.assets.pop(f"{var}_source", None)
 
         return items


### PR DESCRIPTION
We're planning to create a new collection to catalog the source NetCDF assets. Once that collection is ready we'll add links to the source as `via` relations.

For now, we'll drop those assets from the items produced by the stactools package.

cc @pjhartzell

(this is untested at the moment; Will test once my networking stuff is sorted out)