### PR TITLE
[ingest]: Bump pgstac to 0.6.9

### DIFF
--- a/deployment/requirements.txt
+++ b/deployment/requirements.txt
@@ -1,2 +1,2 @@
-pypgstac==0.6.4
+pypgstac==0.6.9
 Jinja2==3.1.2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
 
   database:
     container_name: pctasks-database
-    image: ghcr.io/stac-utils/pgstac:v0.6.6
+    image: ghcr.io/stac-utils/pgstac:v0.6.9
     environment:
       - POSTGRES_USER=username
       - POSTGRES_PASSWORD=password

--- a/pctasks/ingest_task/setup.py
+++ b/pctasks/ingest_task/setup.py
@@ -8,7 +8,7 @@ with open("README.md") as f:
 install_requires = [
     "pctasks.task>=0.1.0",
     "pctasks.ingest>=0.1.0",
-    "pypgstac[psycopg]==0.6.6",
+    "pypgstac[psycopg]==0.6.9",
     "pystac==1.*",
     "smart-open==4.2.0",
     "orjson>=3.5.2",


### PR DESCRIPTION
## Description

Updates the pgstac dependency to 0.6.9, to match the version currently deployed to staging.