### PR TITLE
Create and manually terminate Azure Batch jobs per job definition

### DIFF
--- a/deployment/bin/publish_func
+++ b/deployment/bin/publish_func
@@ -50,7 +50,7 @@ configure() {
     git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 
     if [[ -z ${GITHUB_REPOSITORY} ]]; then
-        GITHUB_REPOSITORY="microsoft/planetary-computer-apis"
+        GITHUB_REPOSITORY="microsoft/planetary-computer-tasks"
     fi
 
     OWNER=$(cut -d '/' -f 1 <<< "$GITHUB_REPOSITORY")

--- a/deployment/helm/published/pctasks-server/templates/deployment.yaml
+++ b/deployment/helm/published/pctasks-server/templates/deployment.yaml
@@ -56,8 +56,6 @@ spec:
               value: "{{ .Values.pctasks.server.dev.api_key }}"
             - name: PCTASKS_SERVER__DEV_AUTH_TOKEN
               value: "{{ .Values.pctasks.server.dev.auth_token }}"
-            - name: PCTASKS_SERVER__RECORD_TABLES__CONNECTION_STRING
-              value: "{{ .Values.pctasks.run.tables.connection_string }}"
 
             {{- if .Values.pctasks.server.access_key.enabled }}
             - name: PCTASKS_SERVER__ACCESS_KEY

--- a/docker-compose.console.yml
+++ b/docker-compose.console.yml
@@ -35,8 +35,6 @@ services:
       # Local secrets provider secrets
       - SECRETS_DB_CONNECTION_STRING=postgresql://username:password@database:5432/postgis
 
-      - PCTASKS_SERVER__RECORD_TABLES__CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;TableEndpoint=http://azurite:10002/devstoreaccount1;
-
       # Run settings #######################################################
 
       ## Azure Storage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,10 @@ services:
       - APP_PORT=8511
       - WEB_CONCURRENCY=1
 
+      - AZURE_TENANT_ID
+      - AZURE_CLIENT_ID
+      - AZURE_CLIENT_SECRET
+
       - PCTASKS_SERVER__DEV=true
       - PCTASKS_SERVER__DEV_API_KEY=hunter2
       - PCTASKS_SERVER__DEV_AUTH_TOKEN=Bearer hunter2
@@ -71,10 +75,19 @@ services:
       # Run settings #######################################################
 
       # Dev executor settings
-      - PCTASKS_RUN__TASK_RUNNER_TYPE=local
+      - PCTASKS_RUN__TASK_RUNNER_TYPE=${PCTASKS_RUN__TASK_RUNNER_TYPE:-local}
       - PCTASKS_RUN__LOCAL_DEV_ENDPOINTS_URL=http://local-dev-endpoints:8512
-      - PCTASKS_RUN__LOCAL_SECRETS=true
+      - PCTASKS_RUN__LOCAL_SECRETS=${PCTASKS_RUN__LOCAL_SECRETS:-true}
       - PCTASKS_RUN__WORKFLOW_RUNNER_TYPE=local
+
+      ## Azure Batch
+
+      - PCTASKS_RUN__BATCH_URL
+      - PCTASKS_RUN__BATCH_KEY
+      - PCTASKS_RUN__BATCH_DEFAULT_POOL_ID
+
+      ## Key Vault
+      - PCTASKS_RUN__KEYVAULT_URL
 
       ## Azure Storage
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,8 +60,6 @@ services:
       - PCTASKS_SERVER__DEV_API_KEY=hunter2
       - PCTASKS_SERVER__DEV_AUTH_TOKEN=Bearer hunter2
 
-      - PCTASKS_SERVER__RECORD_TABLES__CONNECTION_STRING=DefaultEndpointsProtocol=http;AccountName=devstoreaccount1;AccountKey=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==;TableEndpoint=http://azurite:10002/devstoreaccount1;
-
       # Dev storage settings
       - AZURITE_HOST=azurite
       - AZURITE_PORT=10000

--- a/pctasks/client/pctasks/client/workflow/commands.py
+++ b/pctasks/client/pctasks/client/workflow/commands.py
@@ -272,5 +272,7 @@ def cli_handle_workflow(
             cli_output(workflow_id)
             return 0
     else:
+        if workflow_id:
+            workflow_def = workflow_def.copy(update={"workflow_id": workflow_id})
         cli_output(workflow_def.to_yaml())
         return 0

--- a/pctasks/client/pctasks/client/workflow/commands.py
+++ b/pctasks/client/pctasks/client/workflow/commands.py
@@ -262,6 +262,9 @@ def cli_handle_workflow(
     if not client:
         client = PCTasksClient(settings=ClientSettings.from_context(ctx.obj))
 
+    if workflow_id:
+        workflow_def = workflow_def.copy(update={"workflow_id": workflow_id})
+
     if upsert or upsert_and_submit:
         cli_print(f"[green]  Saving {workflow_id}...[/green]")
         client.upsert_workflow(workflow_def)
@@ -272,7 +275,5 @@ def cli_handle_workflow(
             cli_output(workflow_id)
             return 0
     else:
-        if workflow_id:
-            workflow_def = workflow_def.copy(update={"workflow_id": workflow_id})
         cli_output(workflow_def.to_yaml())
         return 0

--- a/pctasks/core/pctasks/core/models/run.py
+++ b/pctasks/core/pctasks/core/models/run.py
@@ -79,11 +79,6 @@ class JobRunStatus(StrEnum):
     PENDING = "pending"
 
 
-class JobPartition(PCBaseModel):
-    definition: JobDefinition
-    partition_id: str
-
-
 class StatusHistoryEntry(PCBaseModel):
     status: str
     timestamp: datetime
@@ -167,14 +162,14 @@ class JobPartitionRunRecord(RunRecord):
         return None
 
     @classmethod
-    def from_job_partition(
+    def from_definition(
         cls,
-        job_partition: JobPartition,
+        partition_id: str,
+        job_definition: JobDefinition,
         run_id: str,
         status: JobPartitionRunStatus = JobPartitionRunStatus.PENDING,
     ) -> "JobPartitionRunRecord":
-        job_id = job_partition.definition.get_id()
-        partition_id = job_partition.partition_id
+        job_id = job_definition.get_id()
         return cls(
             status=status,
             run_id=run_id,
@@ -182,7 +177,7 @@ class JobPartitionRunRecord(RunRecord):
             partition_id=partition_id,
             tasks=[
                 TaskRunRecord.from_task_definition(task, run_id, job_id, partition_id)
-                for task in job_partition.definition.tasks
+                for task in job_definition.tasks
             ],
         )
 

--- a/pctasks/dataset/pctasks/dataset/_cli.py
+++ b/pctasks/dataset/pctasks/dataset/_cli.py
@@ -33,6 +33,7 @@ def create_chunks_cmd(
     submit: bool = False,
     upsert: bool = False,
     target: Optional[str] = None,
+    workflow_id: Optional[str] = None,
 ) -> None:
     """Creates workflow to generate asset chunks for bulk processing.
 
@@ -66,6 +67,7 @@ def create_chunks_cmd(
     cli_handle_workflow(
         ctx,
         workflow_def,
+        workflow_id=workflow_id,
         upsert=upsert,
         upsert_and_submit=submit,
         args={a[0]: a[1] for a in arg},
@@ -85,6 +87,7 @@ def process_items_cmd(
     limit: Optional[int] = None,
     submit: bool = False,
     upsert: bool = False,
+    workflow_id: Optional[str] = None,
 ) -> None:
     """Generate the workflow to create and ingest items.
 
@@ -126,6 +129,7 @@ def process_items_cmd(
     cli_handle_workflow(
         ctx,
         workflow_def,
+        workflow_id=workflow_id,
         upsert=upsert,
         upsert_and_submit=submit,
         args={a[0]: a[1] for a in arg},
@@ -140,6 +144,7 @@ def ingest_collection_cmd(
     target: Optional[str] = None,
     submit: bool = False,
     upsert: bool = False,
+    workflow_id: Optional[str] = None,
 ) -> None:
     """Generate the workflow to ingest a collection.
 
@@ -179,6 +184,7 @@ def ingest_collection_cmd(
     cli_handle_workflow(
         ctx,
         workflow_def,
+        workflow_id=workflow_id,
         upsert=upsert,
         upsert_and_submit=submit,
         args={a[0]: a[1] for a in arg},

--- a/pctasks/dataset/pctasks/dataset/cli.py
+++ b/pctasks/dataset/pctasks/dataset/cli.py
@@ -4,7 +4,13 @@ from typing import List, Optional, Tuple
 import click
 
 from pctasks.client.workflow.options import opt_args
-from pctasks.dataset.utils import opt_collection, opt_ds_config, opt_submit, opt_upsert
+from pctasks.dataset.utils import (
+    opt_collection,
+    opt_ds_config,
+    opt_submit,
+    opt_upsert,
+    opt_workflow_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -34,6 +40,7 @@ def dataset_cmd(ctx: click.Context) -> None:
 )
 @opt_submit
 @opt_upsert
+@opt_workflow_id
 @click.pass_context
 def create_chunks_cmd(
     ctx: click.Context,
@@ -46,6 +53,7 @@ def create_chunks_cmd(
     target: Optional[str] = None,
     submit: bool = False,
     upsert: bool = False,
+    workflow_id: Optional[str] = None,
 ) -> None:
     """Creates workflow to generate asset chunks for bulk processing.
 
@@ -69,6 +77,7 @@ def create_chunks_cmd(
         submit=submit,
         upsert=upsert,
         target=target,
+        workflow_id=workflow_id,
     )
 
 
@@ -97,6 +106,7 @@ def create_chunks_cmd(
 )
 @opt_submit
 @opt_upsert
+@opt_workflow_id
 @click.pass_context
 def process_items_cmd(
     ctx: click.Context,
@@ -111,6 +121,7 @@ def process_items_cmd(
     limit: Optional[int] = None,
     submit: bool = False,
     upsert: bool = False,
+    workflow_id: Optional[str] = None,
 ) -> None:
     """Generate the workflow to create and ingest items.
 
@@ -140,6 +151,7 @@ def process_items_cmd(
         limit=limit,
         submit=submit,
         upsert=upsert,
+        workflow_id=workflow_id,
     )
 
 
@@ -154,6 +166,7 @@ def process_items_cmd(
 )
 @opt_submit
 @opt_upsert
+@opt_workflow_id
 @click.pass_context
 def ingest_collection_cmd(
     ctx: click.Context,
@@ -163,6 +176,7 @@ def ingest_collection_cmd(
     target: Optional[str] = None,
     submit: bool = False,
     upsert: bool = False,
+    workflow_id: Optional[str] = None,
 ) -> None:
     """Generate the workflow to ingest a collection.
 
@@ -187,6 +201,7 @@ def ingest_collection_cmd(
         target=target,
         submit=submit,
         upsert=upsert,
+        workflow_id=workflow_id,
     )
 
 

--- a/pctasks/dataset/pctasks/dataset/utils.py
+++ b/pctasks/dataset/pctasks/dataset/utils.py
@@ -43,3 +43,12 @@ def opt_submit(fn: Callable[..., Any]) -> Callable[..., Any]:
     _opt = click.option("-s", "--submit", is_flag=True, help="Submit the workflow.")
     _opt(fn)
     return fn
+
+
+def opt_workflow_id(fn: Callable[..., Any]) -> Callable[..., Any]:
+    _opt = click.option(
+        "--workflow-id",
+        help=("Workflow ID to use instead of default."),
+    )
+    _opt(fn)
+    return fn

--- a/pctasks/run/pctasks/run/batch/client.py
+++ b/pctasks/run/pctasks/run/batch/client.py
@@ -497,7 +497,7 @@ class BatchClient:
     def terminate_job(self, job_id: str) -> None:
         client = self._ensure_client()
 
-        def _terminate():
+        def _terminate() -> None:
             try:
                 client.job.terminate(job_id=job_id)
             except batchmodels.BatchErrorException as e:

--- a/pctasks/run/pctasks/run/models.py
+++ b/pctasks/run/pctasks/run/models.py
@@ -117,7 +117,7 @@ class HandleTaskResultMessage(PCBaseModel):
 class JobPartition(PCBaseModel):
     definition: JobDefinition
     partition_id: str
-    task_data: Dict[str, PreparedTaskData]
+    task_data: List[PreparedTaskData]
 
 
 class JobPartitionSubmitMessage(PCBaseModel):

--- a/pctasks/run/pctasks/run/models.py
+++ b/pctasks/run/pctasks/run/models.py
@@ -6,7 +6,7 @@ from pydantic import Field
 from pctasks.core.constants import TASK_SUBMIT_MESSAGE_TYPE
 from pctasks.core.models.base import PCBaseModel, RunRecordId
 from pctasks.core.models.config import BlobConfig
-from pctasks.core.models.run import JobPartition, TaskRunStatus
+from pctasks.core.models.run import TaskRunStatus
 from pctasks.core.models.task import (
     CompletedTaskResult,
     FailedTaskResult,
@@ -16,15 +16,13 @@ from pctasks.core.models.task import (
     WaitTaskResult,
 )
 from pctasks.core.models.tokens import StorageAccountTokens
-from pctasks.core.models.workflow import WorkflowSubmitMessage
+from pctasks.core.models.workflow import JobDefinition, WorkflowSubmitMessage
 from pctasks.core.utils import StrEnum
 
 logger = logging.getLogger(__name__)
 
 
 class TaskSubmitMessage(PCBaseModel):
-    instance_id: Optional[str]
-    """The instance ID of the task orchestrator."""
     dataset_id: str
     run_id: str
     job_id: str
@@ -46,11 +44,19 @@ class TaskSubmitMessage(PCBaseModel):
         )
 
 
+class PreparedTaskData(PCBaseModel):
+    image: str
+    environment: Optional[Dict[str, str]]
+    tags: Optional[Dict[str, str]]
+    tokens: Optional[Dict[str, StorageAccountTokens]]
+    runner_info: Dict[str, Any]
+
+
 class PreparedTaskSubmitMessage(PCBaseModel):
     task_submit_message: TaskSubmitMessage
     task_run_message: TaskRunMessage
     task_input_blob_config: BlobConfig
-    task_tags: Optional[Dict[str, str]] = None
+    task_data: PreparedTaskData
 
 
 class PreparedWorkflowSubmitMessage(PCBaseModel):
@@ -106,6 +112,12 @@ class HandleTaskResultMessage(PCBaseModel):
     errors: Optional[List[str]] = None
     log_uri: str
     """The URI of the task log file."""
+
+
+class JobPartition(PCBaseModel):
+    definition: JobDefinition
+    partition_id: str
+    task_data: Dict[str, PreparedTaskData]
 
 
 class JobPartitionSubmitMessage(PCBaseModel):

--- a/pctasks/run/pctasks/run/task/argo.py
+++ b/pctasks/run/pctasks/run/task/argo.py
@@ -89,5 +89,5 @@ class ArgoTaskRunner(TaskRunner):
             namespace=namespace, argo_workflow_name=name
         )
 
-    def cleanup(self, task_infos: Dict[str, Dict[str, Any]]) -> None:
+    def cleanup(self, task_infos: List[Dict[str, Any]]) -> None:
         pass

--- a/pctasks/run/pctasks/run/task/argo.py
+++ b/pctasks/run/pctasks/run/task/argo.py
@@ -1,7 +1,8 @@
 import logging
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pctasks.core.models.run import TaskRunStatus
+from pctasks.core.models.task import TaskDefinition
 from pctasks.core.utils import map_opt
 from pctasks.run.argo.client import ArgoClient
 from pctasks.run.constants import MAX_MISSING_POLLS
@@ -33,6 +34,17 @@ class ArgoTaskRunner(TaskRunner):
         self.argo_client = ArgoClient(
             host=argo_host, token=argo_token, namespace=settings.argo_namespace
         )
+
+    def prepare_task_info(
+        self,
+        dataset_id: str,
+        run_id: str,
+        job_id: str,
+        task_def: TaskDefinition,
+        image: str,
+        task_tags: Optional[Dict[str, str]],
+    ) -> Dict[str, Any]:
+        return {}
 
     def submit_tasks(
         self, prepared_tasks: List[PreparedTaskSubmitMessage]
@@ -76,3 +88,6 @@ class ArgoTaskRunner(TaskRunner):
         self.argo_client.terminate_workflow(
             namespace=namespace, argo_workflow_name=name
         )
+
+    def cleanup(self, task_infos: Dict[str, Dict[str, Any]]) -> None:
+        pass

--- a/pctasks/run/pctasks/run/task/base.py
+++ b/pctasks/run/pctasks/run/task/base.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
+from pctasks.core.models.task import TaskDefinition
 
 from pctasks.run.models import (
     FailedTaskSubmitResult,
@@ -15,6 +16,18 @@ class TaskRunner(ABC):
         self.settings = settings
 
     @abstractmethod
+    def prepare_task_info(
+        self,
+        dataset_id: str,
+        run_id: str,
+        job_id: str,
+        task_def: TaskDefinition,
+        image: str,
+        task_tags: Optional[Dict[str, str]],
+    ) -> Dict[str, Any]:
+        pass
+
+    @abstractmethod
     def submit_tasks(
         self, prepared_tasks: List[PreparedTaskSubmitMessage]
     ) -> List[Union[SuccessfulTaskSubmitResult, FailedTaskSubmitResult]]:
@@ -28,4 +41,13 @@ class TaskRunner(ABC):
 
     @abstractmethod
     def cancel_task(self, runner_id: Dict[str, Any]) -> None:
+        pass
+
+    @abstractmethod
+    def cleanup(self, task_infos: Dict[str, Dict[str, Any]]) -> None:
+        """Performs any cleanup after tasks have finished running.
+
+        task_infos is a dictionary of task IDs to task info dictionaries
+        that were returned by prepare_task_info.
+        """
         pass

--- a/pctasks/run/pctasks/run/task/base.py
+++ b/pctasks/run/pctasks/run/task/base.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional, Union
-from pctasks.core.models.task import TaskDefinition
 
+from pctasks.core.models.task import TaskDefinition
 from pctasks.run.models import (
     FailedTaskSubmitResult,
     PreparedTaskSubmitMessage,

--- a/pctasks/run/pctasks/run/task/base.py
+++ b/pctasks/run/pctasks/run/task/base.py
@@ -44,10 +44,10 @@ class TaskRunner(ABC):
         pass
 
     @abstractmethod
-    def cleanup(self, task_infos: Dict[str, Dict[str, Any]]) -> None:
+    def cleanup(self, task_infos: List[Dict[str, Any]]) -> None:
         """Performs any cleanup after tasks have finished running.
 
-        task_infos is a dictionary of task IDs to task info dictionaries
+        task_infos is a list of dictionaries
         that were returned by prepare_task_info.
         """
         pass

--- a/pctasks/run/pctasks/run/task/batch.py
+++ b/pctasks/run/pctasks/run/task/batch.py
@@ -234,9 +234,9 @@ class BatchTaskRunner(TaskRunner):
                 job_id=task_id.batch_job_id, task_id=task_id.batch_task_id
             )
 
-    def cleanup(self, task_infos: Dict[str, Dict[str, Any]]) -> None:
+    def cleanup(self, task_infos: List[Dict[str, Any]]) -> None:
         job_ids = set()
-        for info in task_infos.values():
+        for info in task_infos:
             job_ids.add(info[JOB_ID_KEY])
         if job_ids:
             with BatchClient(self.settings.batch_settings) as batch_client:

--- a/pctasks/run/pctasks/run/task/batch.py
+++ b/pctasks/run/pctasks/run/task/batch.py
@@ -4,9 +4,8 @@ from dataclasses import dataclass
 from threading import Lock
 from typing import Any, Dict, List, Optional, Union
 
-import azure.batch.models as batchmodels
-
 from pctasks.core.models.run import TaskRunStatus
+from pctasks.core.models.task import TaskDefinition
 from pctasks.core.utils import map_opt
 from pctasks.run.batch.client import BatchClient
 from pctasks.run.batch.model import BatchTaskId
@@ -25,6 +24,8 @@ from pctasks.run.task.base import TaskRunner
 logger = logging.getLogger(__name__)
 
 BATCH_POOL_ID_TAG = "batch_pool_id"
+
+JOB_ID_KEY = "job_id"
 
 
 class BatchTaskRunnerError(Exception):
@@ -65,6 +66,31 @@ class BatchTaskInfo:
 
 
 class BatchTaskRunner(TaskRunner):
+    def prepare_task_info(
+        self,
+        dataset_id: str,
+        run_id: str,
+        job_id: str,
+        task_def: TaskDefinition,
+        image: str,
+        task_tags: Optional[Dict[str, str]],
+    ) -> Dict[str, Any]:
+        pool_id = get_pool_id(task_tags, self.settings.batch_settings)
+        batch_job_id = make_batch_job_id(dataset_id, job_id, run_id, pool_id)
+        with BatchClient(self.settings.batch_settings) as batch_client:
+            existing_job = batch_client.get_job(batch_job_id)
+            if not existing_job:
+                if not batch_client.get_pool(pool_id):
+                    raise BatchTaskRunnerError(f"Batch pool {pool_id} not found.")
+
+                batch_job_id = batch_client.add_job(
+                    job_id=batch_job_id,
+                    pool_id=pool_id,
+                    make_unique=False,
+                    terminate_on_tasks_complete=False,
+                )
+        return {JOB_ID_KEY: batch_job_id}
+
     def submit_tasks(
         self, prepared_tasks: List[PreparedTaskSubmitMessage]
     ) -> List[Union[SuccessfulTaskSubmitResult, FailedTaskSubmitResult]]:
@@ -79,13 +105,13 @@ class BatchTaskRunner(TaskRunner):
 
             for i, prepared_task in enumerate(prepared_tasks):
                 submit_msg = prepared_task.task_submit_message
-                run_id = submit_msg.run_id
-                job_id = submit_msg.job_id
+                # run_id = submit_msg.run_id
+                # job_id = submit_msg.job_id
                 part_id = submit_msg.partition_id
                 task_id = submit_msg.definition.id
                 run_msg = prepared_task.task_run_message
                 task_input_blob_config = prepared_task.task_input_blob_config
-                task_tags = prepared_task.task_tags
+                task_tags = prepared_task.task_data.tags
 
                 task_id_for_batch = create_batch_task_id(part_id, task_id)
 
@@ -105,9 +131,7 @@ class BatchTaskRunner(TaskRunner):
                         ["--account-url", task_input_blob_config.account_url]
                     )
 
-                batch_job_id = make_batch_job_id(
-                    submit_msg.dataset_id, job_id, run_id, pool_id
-                )
+                batch_job_id = prepared_task.task_data.runner_info[JOB_ID_KEY]
 
                 batch_task_id = make_valid_batch_id(task_id_for_batch)
 
@@ -135,88 +159,35 @@ class BatchTaskRunner(TaskRunner):
                 batch_job_id = batch_job_info.job_prefix
                 pool_id = batch_job_info.pool_id
 
-                retry_count = 0
-                task_submitted = False
-
                 try:
+                    # Lock to decrease pressure on Azure Batch API
                     with job_locks[batch_job_id]:
-                        # Try twice in case job completes before we can submit tasks
-                        while not task_submitted and retry_count <= 1:
-                            try:
-                                existing_jobs = batch_client.list_jobs(batch_job_id)
-                                existing_job = False
-                                if len(existing_jobs) > 0:
-                                    for job in existing_jobs:
-                                        if job.state == batchmodels.JobState.active:
-                                            batch_job_id = job.id
-                                            existing_job = True
-                                            break
-                                    if not existing_job:
-                                        # Create a job ID that doesn't clash
-                                        # with an existing job
-                                        batch_job_id = make_valid_batch_id(
-                                            f"{batch_job_id}:{len(existing_jobs)}"
-                                        )
 
-                                if not existing_job:
-                                    # Create the job
-                                    if not batch_client.get_pool(pool_id):
-                                        raise BatchTaskRunnerError(
-                                            f"Batch pool {pool_id} not found."
-                                        )
+                        # Submit the tasks
+                        task_errors = batch_client.add_collection(
+                            batch_job_id,
+                            [i.task for i in batch_task_infos],
+                        )
 
-                                    batch_job_id = batch_client.add_job(
-                                        job_id=batch_job_id,
-                                        pool_id=pool_id,
-                                        make_unique=False,
-                                    )
-
-                                else:
-                                    logger.info(
-                                        "Found existing batch job " f"{batch_job_id}."
-                                    )
-
-                                # Submit the tasks
-                                task_errors = batch_client.add_collection(
-                                    batch_job_id,
-                                    [i.task for i in batch_task_infos],
+                        # Process the results from Azure Batch
+                        for i, task_error in enumerate(task_errors):
+                            batch_task_info = batch_task_infos[i]
+                            task_id = batch_task_info.task.task_id
+                            if task_error:
+                                err: Any = task_error.message
+                                error_msg = err.value
+                                submit_results[
+                                    batch_task_info.index
+                                ] = FailedTaskSubmitResult(errors=[error_msg])
+                            else:
+                                submit_results[
+                                    batch_task_info.index
+                                ] = SuccessfulTaskSubmitResult(
+                                    task_runner_id=BatchTaskId(
+                                        batch_job_id=batch_job_id,
+                                        batch_task_id=task_id,
+                                    ).dict(),
                                 )
-
-                                task_submitted = True
-
-                                # Process the results from Azure Batch
-                                for i, task_error in enumerate(task_errors):
-                                    batch_task_info = batch_task_infos[i]
-                                    task_id = batch_task_info.task.task_id
-                                    if task_error:
-                                        err: Any = task_error.message
-                                        error_msg = err.value
-                                        submit_results[
-                                            batch_task_info.index
-                                        ] = FailedTaskSubmitResult(errors=[error_msg])
-                                    else:
-                                        submit_results[
-                                            batch_task_info.index
-                                        ] = SuccessfulTaskSubmitResult(
-                                            task_runner_id=BatchTaskId(
-                                                batch_job_id=batch_job_id,
-                                                batch_task_id=task_id,
-                                            ).dict(),
-                                        )
-
-                            except batchmodels.BatchErrorException as e:
-                                logger.exception(e)
-                                logger.warning("RETRYING BATCH JOB SUBMIT...")
-                                error: Any = e.error  # Avoid type hinting error
-                                if error.code == "JobCompleted":
-                                    if retry_count > 1:
-                                        raise
-                                    retry_count += 1
-                                else:
-                                    raise
-
-                    if not batch_job_id:
-                        raise BatchTaskRunnerError("Failed to create batch job.")
 
                 except Exception as e:
                     logger.exception(e)
@@ -262,3 +233,12 @@ class BatchTaskRunner(TaskRunner):
             batch_client.terminate_task(
                 job_id=task_id.batch_job_id, task_id=task_id.batch_task_id
             )
+
+    def cleanup(self, task_infos: Dict[str, Dict[str, Any]]) -> None:
+        job_ids = set()
+        for info in task_infos.values():
+            job_ids.add(info[JOB_ID_KEY])
+        if job_ids:
+            with BatchClient(self.settings.batch_settings) as batch_client:
+                for job_id in job_ids:
+                    batch_client.terminate_job(job_id=job_id)

--- a/pctasks/run/pctasks/run/task/local.py
+++ b/pctasks/run/pctasks/run/task/local.py
@@ -1,10 +1,11 @@
 import json
 import logging
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 import requests
 
 from pctasks.core.models.run import TaskRunStatus
+from pctasks.core.models.task import TaskDefinition
 from pctasks.run.constants import MAX_MISSING_POLLS
 from pctasks.run.models import (
     FailedTaskSubmitResult,
@@ -27,13 +28,24 @@ class LocalTaskRunner(TaskRunner):
     def __init__(self, local_dev_endpoints_url: str):
         self.local_dev_endpoints_url = local_dev_endpoints_url
 
+    def prepare_task_info(
+        self,
+        dataset_id: str,
+        run_id: str,
+        job_id: str,
+        task_def: TaskDefinition,
+        image: str,
+        task_tags: Optional[Dict[str, str]],
+    ) -> Dict[str, Any]:
+        return {}
+
     def submit_tasks(
         self, prepared_tasks: List[PreparedTaskSubmitMessage]
     ) -> List[Union[SuccessfulTaskSubmitResult, FailedTaskSubmitResult]]:
         results: List[Union[SuccessfulTaskSubmitResult, FailedTaskSubmitResult]] = []
         for prepared_task in prepared_tasks:
             task_input_blob_config = prepared_task.task_input_blob_config
-            task_tags = prepared_task.task_tags
+            task_tags = prepared_task.task_data.tags
             args = [
                 "task",
                 "run",
@@ -86,4 +98,7 @@ class LocalTaskRunner(TaskRunner):
 
     def cancel_task(self, runner_id: Dict[str, Any]) -> None:
         # No-op
+        pass
+
+    def cleanup(self, task_infos: Dict[str, Dict[str, Any]]) -> None:
         pass

--- a/pctasks/run/pctasks/run/task/local.py
+++ b/pctasks/run/pctasks/run/task/local.py
@@ -100,5 +100,5 @@ class LocalTaskRunner(TaskRunner):
         # No-op
         pass
 
-    def cleanup(self, task_infos: Dict[str, Dict[str, Any]]) -> None:
+    def cleanup(self, task_infos: List[Dict[str, Any]]) -> None:
         pass

--- a/pctasks/run/pctasks/run/workflow/local.py
+++ b/pctasks/run/pctasks/run/workflow/local.py
@@ -1,6 +1,7 @@
 from concurrent import futures
 from threading import Lock
 from typing import Optional
+from pctasks.cli.cli import setup_logging
 
 from pctasks.core.models.run import WorkflowRunStatus
 from pctasks.core.models.workflow import WorkflowSubmitMessage, WorkflowSubmitResult
@@ -38,6 +39,7 @@ class LocalWorkflowRunner(WorkflowRunner):
                 _thread_pool = futures.ThreadPoolExecutor(max_workers=1)
 
             def _execute_workflow(s: WorkflowSubmitMessage) -> None:
+                setup_logging()
                 if self.cosmosdb_settings.is_cosmosdb_emulator():
                     with ignore_ssl_warnings():
                         executor.execute_workflow(s)

--- a/pctasks/run/pctasks/run/workflow/local.py
+++ b/pctasks/run/pctasks/run/workflow/local.py
@@ -1,7 +1,6 @@
 from concurrent import futures
 from threading import Lock
 from typing import Optional
-from pctasks.cli.cli import setup_logging
 
 from pctasks.core.models.run import WorkflowRunStatus
 from pctasks.core.models.workflow import WorkflowSubmitMessage, WorkflowSubmitResult
@@ -30,7 +29,6 @@ class LocalWorkflowRunner(WorkflowRunner):
     def submit_workflow(
         self, submit_msg: WorkflowSubmitMessage
     ) -> WorkflowSubmitResult:
-
         global _workflow_count
         global _thread_pool
         executor = RemoteWorkflowExecutor(self.get_executor_config())
@@ -39,7 +37,6 @@ class LocalWorkflowRunner(WorkflowRunner):
                 _thread_pool = futures.ThreadPoolExecutor(max_workers=1)
 
             def _execute_workflow(s: WorkflowSubmitMessage) -> None:
-                setup_logging()
                 if self.cosmosdb_settings.is_cosmosdb_emulator():
                     with ignore_ssl_warnings():
                         executor.execute_workflow(s)

--- a/pctasks/run/tests/test_messages.py
+++ b/pctasks/run/tests/test_messages.py
@@ -5,7 +5,8 @@ from pctasks.dev.secrets import TempSecrets
 from pctasks.dev.tables import TempTable
 from pctasks.run.models import TaskSubmitMessage
 from pctasks.run.settings import RunSettings
-from pctasks.run.task.prepare import prepare_task
+from pctasks.run.task import get_task_runner
+from pctasks.run.task.prepare import prepare_task, prepare_task_data
 
 
 def test_image_key_environment_merged():
@@ -44,7 +45,6 @@ def test_image_key_environment_merged():
 
             submit_msg = TaskSubmitMessage(
                 dataset_id="test-dataset-id",
-                instance_id="test_instance_id",
                 job_id="job-id",
                 partition_id="0",
                 run_id=run_id,
@@ -57,10 +57,22 @@ def test_image_key_environment_merged():
                 ),
             )
 
+            task_data = prepare_task_data(
+                dataset_id=submit_msg.dataset_id,
+                run_id=submit_msg.run_id,
+                job_id=submit_msg.job_id,
+                task_def=submit_msg.definition,
+                tokens=submit_msg.tokens,
+                target_environment=submit_msg.target_environment,
+                settings=exec_settings,
+                task_runner=get_task_runner(exec_settings),
+            )
+
             prepared_task = prepare_task(
                 submit_msg=submit_msg,
                 run_id=run_id,
                 settings=exec_settings,
+                task_data=task_data,
             )
 
             run_msg = prepared_task.task_run_message

--- a/scripts/cluster
+++ b/scripts/cluster
@@ -145,6 +145,7 @@ function update_cluster() {
 
     COSMOSDB_VARS=""
     if [ "${PCTASKS_COSMOSDB__URL}" ]; then
+        require_env "PCTASKS_COSMOSDB__KEY";
         COSMOSDB_VARS="--set pctasks.cosmosdb.url=${PCTASKS_COSMOSDB__URL} \
             --set pctasks.cosmosdb.key=${PCTASKS_COSMOSDB__KEY}"
     fi
@@ -152,6 +153,39 @@ function update_cluster() {
     if [ "${PCTASKS_COSMOSDB__TEST_CONTAINER_SUFFIX}" ]; then
         COSMOSDB_VARS="${COSMOSDB_VARS} \
             --set pctasks.cosmosdb.dev.test_container_suffix=${PCTASKS_COSMOSDB__TEST_CONTAINER_SUFFIX}"
+    fi
+
+    BATCH_VARS=""
+    if [ "${PCTASKS_RUN__BATCH_URL}" ]; then
+        require_env "PCTASKS_RUN__BATCH_KEY";
+        require_env "PCTASKS_RUN__BATCH_DEFAULT_POOL_ID";
+        BATCH_VARS="--set pctasks.run.task_runner_type=batch \
+            --set pctasks.run.batch.enabled=true \
+            --set pctasks.run.batch.url=${PCTASKS_RUN__BATCH_URL} \
+            --set pctasks.run.batch.key=${PCTASKS_RUN__BATCH_KEY} \
+            --set pctasks.run.batch.default_pool_id=${PCTASKS_RUN__BATCH_DEFAULT_POOL_ID}"
+    fi
+
+    KV_VARS=""
+    if [ "${PCTASKS_RUN__KEYVAULT_URL}" ]; then
+        require_env "AZURE_TENANT_ID";
+        require_env "AZURE_CLIENT_ID";
+        require_env "AZURE_CLIENT_SECRET";
+        KV_VARS="--set pctasks.run.dev.secrets.enabled=false \
+           --set pctasks.run.keyvault.enabled=true \
+           --set pctasks.run.keyvault.url=${PCTASKS_RUN__KEYVAULT_URL} \
+           --set pctasks.run.keyvault.sp_tenant_id=${AZURE_TENANT_ID} \
+           --set pctasks.run.keyvault.sp_client_id=${AZURE_CLIENT_ID} \
+           --set pctasks.run.keyvault.sp_client_secret=${AZURE_CLIENT_SECRET}"
+    fi
+
+    BLOB_VARS=""
+    if [ "${PCTASKS_RUN__BLOB_ACCOUNT_NAME}" ]; then
+        require_env "PCTASKS_RUN__BLOB_ACCOUNT_URL";
+        require_env "PCTASKS_RUN__BLOB_ACCOUNT_KEY";
+        BLOB_VARS="--set pctasks.run.blob.account_name=${PCTASKS_RUN__BLOB_ACCOUNT_NAME} \
+            --set pctasks.run.blob.account_url=${PCTASKS_RUN__BLOB_ACCOUNT_URL} \
+            --set pctasks.run.blob.account_key=${PCTASKS_RUN__BLOB_ACCOUNT_KEY}"
     fi
 
     # Set pctasks.deploy.podAnnotations.updated to force a new deployment
@@ -162,7 +196,7 @@ function update_cluster() {
         -f cluster/dev-values.yaml \
         --create-namespace \
         --set pctasks.server.deploy.podAnnotations.updated="$(date)" \
-        --set pctasks.run.argo.token="${ARGO_TOKEN}" ${COSMOSDB_VARS}
+        --set pctasks.run.argo.token="${ARGO_TOKEN}" ${COSMOSDB_VARS} ${BATCH_VARS} ${KV_VARS} ${BLOB_VARS}
 
     echo "Installing ingress-nginx..."
     # TODO: Move to helm chart
@@ -175,14 +209,14 @@ function update_cluster() {
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${SETUP}" ]; then
-        create_cluster;
-        update_registry;
-        update_cluster;
+        create_cluster
+        update_registry
+        update_cluster
     fi
 
     if [ "${UPDATE}" ]; then
-        update_registry;
-        update_cluster;
+        update_registry
+        update_cluster
     fi
 
     if [ "${GET_ARGO_TOKEN}" ]; then
@@ -196,8 +230,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     if [ "${RECREATE}" ]; then
         echo " -- RECREATING KIND CLUSTER"
         kind delete cluster --name ${KIND_CLUSTER_NAME}
-        create_cluster;
-        update_cluster;
+        create_cluster
+        update_cluster
     fi
 
     if [ "${DELETE}" ]; then

--- a/scripts/env
+++ b/scripts/env
@@ -39,3 +39,12 @@ function setup_docker_network() {
                 pctasks-network
         fi
 }
+
+function require_env() {
+    v=$(eval echo \$${1})
+
+    if [[ -z ${v} ]]; then
+        echo "${1} must be set as environment variable" >&2
+        exit 1
+    fi
+}


### PR DESCRIPTION
The main change in this PR is to allow batch jobs to be created before Job Partitions are generated, and manually terminated as part of a cleanup step in the remote workflow executor. This required refactoring the task preparation step, splitting out the fetching of image-key information and templating of secrets from the per-task configuration generated. This has the added benefit of reducing reads to keyvault and the Azure Tables storaging the image key data.

Other changes are minor and documented in commits.