### PR TITLE
Reduce API calls on Azure Batch and CosmosDB

### DIFF
--- a/deployment/cosmosdb/scripts/stored_procs/workflow-runs/bulkput-workflowruns.js
+++ b/deployment/cosmosdb/scripts/stored_procs/workflow-runs/bulkput-workflowruns.js
@@ -1,0 +1,60 @@
+/**
+*  From https://github.com/Azure/azure-cosmosdb-js-server/blob/master/samples/stored-procedures/BulkImport.js
+*
+* This script called as stored procedure to import lots of documents in one batch.
+* The script sets response body to the number of docs imported and is called multiple times
+* by the client until total number of docs desired by the client is imported.
+* @param  {Object[]} docs - Array of documents to import.
+*/
+function bulkPut(docs) {
+    var collection = getContext().getCollection();
+    var collectionLink = collection.getSelfLink();
+
+    // The count of imported docs, also used as current doc index.
+    var count = 0;
+
+    // Validate input.
+    if (!docs) throw new Error("The array is undefined or null.");
+
+    var docsLength = docs.length;
+    if (docsLength == 0) {
+        getContext().getResponse().setBody(0);
+        return;
+    }
+
+    // Call the CRUD API to create a document.
+    tryCreate(docs[count], callback);
+
+    // Note that there are 2 exit conditions:
+    // 1) The createDocument request was not accepted.
+    //    In this case the callback will not be called, we just call setBody and we are done.
+    // 2) The callback was called docs.length times.
+    //    In this case all documents were created and we don't need to call tryCreate anymore. Just call setBody and we are done.
+    function tryCreate(doc, callback) {
+        var isAccepted = collection.createDocument(collectionLink, doc, callback);
+
+        // If the request was accepted, callback will be called.
+        // Otherwise report current count back to the client,
+        // which will call the script again with remaining set of docs.
+        // This condition will happen when this stored procedure has been running too long
+        // and is about to get cancelled by the server. This will allow the calling client
+        // to resume this batch from the point we got to before isAccepted was set to false
+        if (!isAccepted) getContext().getResponse().setBody(count);
+    }
+
+    // This is called when collection.createDocument is done and the document has been persisted.
+    function callback(err, doc, options) {
+        if (err) throw err;
+
+        // One more document has been inserted, increment the count.
+        count++;
+
+        if (count >= docsLength) {
+            // If we have created all documents, we are done. Just set the response.
+            getContext().getResponse().setBody(count);
+        } else {
+            // Create next document.
+            tryCreate(docs[count], callback);
+        }
+    }
+}

--- a/deployment/terraform/resources/cosmosdb.tf
+++ b/deployment/terraform/resources/cosmosdb.tf
@@ -49,6 +49,16 @@ resource "azurerm_cosmosdb_sql_trigger" "post-all-workflowruns" {
   type         = "Post"
 }
 
+resource "azurerm_cosmosdb_sql_stored_procedure" "bulkput-workflowruns" {
+  name         = "bulkput-workflowruns"
+  resource_group_name = data.azurerm_cosmosdb_account.pctasks.resource_group_name
+  account_name        = data.azurerm_cosmosdb_account.pctasks.name
+  database_name       = azurerm_cosmosdb_sql_database.pctasks.name
+  container_name      = azurerm_cosmosdb_sql_container.workflowruns.name
+
+  body         = file("${path.module}/../../cosmosdb/scripts/stored_procs/workflow-runs/bulkput-workflowruns.js")
+}
+
 ## Records
 
 resource "azurerm_cosmosdb_sql_container" "records" {

--- a/pctasks/core/pctasks/core/cosmos/containers/workflow_runs.py
+++ b/pctasks/core/pctasks/core/cosmos/containers/workflow_runs.py
@@ -17,7 +17,11 @@ T = TypeVar("T", WorkflowRunRecord, JobPartitionRunRecord)
 
 PARTITION_KEY = "/run_id"
 
-STORED_PROCEDURES: Dict[ContainerOperation, Dict[Type[BaseModel], str]] = {}
+STORED_PROCEDURES: Dict[ContainerOperation, Dict[Type[BaseModel], str]] = {
+    ContainerOperation.BULK_PUT: {
+        JobPartitionRunRecord: "bulkput-workflowruns",
+    }
+}
 
 TRIGGERS: Dict[ContainerOperation, Dict[TriggerType, str]] = {
     ContainerOperation.PUT: {TriggerType.POST: "post-all-workflowruns"}

--- a/pctasks/core/pctasks/core/cosmos/settings.py
+++ b/pctasks/core/pctasks/core/cosmos/settings.py
@@ -39,6 +39,8 @@ class CosmosDBSettings(PCTasksSettings):
     workflow_runs_container_name: str = DEFAULT_WORKFLOW_RUNS_CONTAINER
     records_container_name: str = DEFAULT_RECORDS_CONTAINER
 
+    max_bulk_put_size: int = 250
+
     def get_workflows_container_name(self) -> str:
         if self.test_container_suffix:
             return f"tmp-{self.workflows_container_name}-{self.test_container_suffix}"

--- a/pctasks/run/pctasks/run/batch/client.py
+++ b/pctasks/run/pctasks/run/batch/client.py
@@ -469,6 +469,25 @@ class BatchClient:
         else:
             return (TaskRunStatus.SUBMITTED, None)
 
+    def get_failed_tasks(self, job_id: str) -> List[str]:
+        client = self._ensure_client()
+        completed_tasks = client.task.list(
+            job_id,
+            task_list_options=batchmodels.TaskListOptions(
+                filter="state eq 'completed'"
+            ),
+        )
+        result = []
+        for task in completed_tasks:
+            t = cast(batchmodels.CloudTask, task)
+            execution_info = cast(
+                batchmodels.TaskExecutionInformation,
+                t.execution_info,
+            )
+            if execution_info.exit_code != 0:
+                result.append(t.id)
+        return result
+
     def get_pool(self, pool_id: str) -> Optional[batchmodels.PoolInformation]:
         client = self._ensure_client()
 

--- a/pctasks/run/pctasks/run/batch/client.py
+++ b/pctasks/run/pctasks/run/batch/client.py
@@ -1,6 +1,6 @@
 import logging
 from datetime import datetime, timedelta
-from typing import Any, Callable, Iterable, List, Optional, Tuple, cast
+from typing import Any, Callable, Dict, Iterable, List, Optional, Tuple, cast
 
 import azure.batch.batch_auth as batchauth
 import azure.batch.models as batchmodels
@@ -66,6 +66,7 @@ class BatchClient:
 
     def __init__(self, settings: BatchSettings):
         self.settings = settings
+        self._client: Optional[BatchServiceClient] = None
 
         self.credentials = batchauth.SharedKeyCredentials(
             self.settings.get_batch_name(), self.settings.key
@@ -469,7 +470,7 @@ class BatchClient:
         else:
             return (TaskRunStatus.SUBMITTED, None)
 
-    def get_failed_tasks(self, job_id: str) -> List[str]:
+    def get_failed_tasks(self, job_id: str) -> Dict[str, str]:
         client = self._ensure_client()
         completed_tasks = client.task.list(
             job_id,
@@ -477,15 +478,19 @@ class BatchClient:
                 filter="state eq 'completed'"
             ),
         )
-        result = []
+        result: Dict[str, str] = {}
         for task in completed_tasks:
             t = cast(batchmodels.CloudTask, task)
             execution_info = cast(
                 batchmodels.TaskExecutionInformation,
                 t.execution_info,
             )
-            if execution_info.exit_code != 0:
-                result.append(t.id)
+            if execution_info.result == batchmodels.TaskExecutionResult.failure:
+                if execution_info.failure_info and execution_info.failure_info.message:
+                    result[t.id] = execution_info.failure_info.message
+                else:
+                    result[t.id] = "Azure Batch task failed without error message"
+
         return result
 
     def get_pool(self, pool_id: str) -> Optional[batchmodels.PoolInformation]:

--- a/pctasks/run/pctasks/run/task/argo.py
+++ b/pctasks/run/pctasks/run/task/argo.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 from pctasks.core.models.run import TaskRunStatus
 from pctasks.core.models.task import TaskDefinition
@@ -82,6 +82,22 @@ class ArgoTaskRunner(TaskRunner):
                 task_status=task_status,
                 poll_errors=map_opt(lambda e: [e], error_message),
             )
+
+    def get_failed_tasks(
+        self,
+        runner_ids: Dict[str, Dict[str, Dict[str, Any]]],
+    ) -> Dict[str, Set[str]]:
+        # TODO: Optimize implementation
+        return {
+            partition_id: set(
+                [
+                    task_id
+                    for task_id, runner_id in task_map.items()
+                    if self.poll_task(runner_id, 0).task_status == TaskRunStatus.FAILED
+                ]
+            )
+            for partition_id, task_map in runner_ids.items()
+        }
 
     def cancel_task(self, runner_id: Dict[str, Any]) -> None:
         namespace, name = runner_id["namespace"], runner_id["name"]

--- a/pctasks/run/pctasks/run/task/base.py
+++ b/pctasks/run/pctasks/run/task/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Set, Union
+from typing import Any, Dict, List, Optional, Union
 
 from pctasks.core.models.task import TaskDefinition
 from pctasks.run.models import (
@@ -43,13 +43,14 @@ class TaskRunner(ABC):
     def get_failed_tasks(
         self,
         runner_ids: Dict[str, Dict[str, Dict[str, Any]]],
-    ) -> Dict[str, Set[str]]:
+    ) -> Dict[str, Dict[str, str]]:
         """Finds failed tasks.
 
         runner_ids is a dictionary of partition IDs to a
         dictionary of task IDs to runner IDs.
 
-        Returns a dictionary of partition IDs to a set of failed task IDs.
+        Returns a dictionary of partition IDs to a
+        map of failed task IDs to error messages.
         """
         pass
 

--- a/pctasks/run/pctasks/run/task/base.py
+++ b/pctasks/run/pctasks/run/task/base.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 from pctasks.core.models.task import TaskDefinition
 from pctasks.run.models import (
@@ -37,6 +37,20 @@ class TaskRunner(ABC):
     def poll_task(
         self, runner_id: Dict[str, Any], previous_poll_count: int
     ) -> TaskPollResult:
+        pass
+
+    @abstractmethod
+    def get_failed_tasks(
+        self,
+        runner_ids: Dict[str, Dict[str, Dict[str, Any]]],
+    ) -> Dict[str, Set[str]]:
+        """Finds failed tasks.
+
+        runner_ids is a dictionary of partition IDs to a
+        dictionary of task IDs to runner IDs.
+
+        Returns a dictionary of partition IDs to a set of failed task IDs.
+        """
         pass
 
     @abstractmethod

--- a/pctasks/run/pctasks/run/task/local.py
+++ b/pctasks/run/pctasks/run/task/local.py
@@ -1,6 +1,6 @@
 import json
 import logging
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Set, Union
 
 import requests
 
@@ -95,6 +95,21 @@ class LocalTaskRunner(TaskRunner):
         except Exception as e:
             logger.exception(e)
             return TaskPollResult(task_status=TaskRunStatus.FAILED)
+
+    def get_failed_tasks(
+        self,
+        runner_ids: Dict[str, Dict[str, Dict[str, Any]]],
+    ) -> Dict[str, Set[str]]:
+        return {
+            partition_id: set(
+                [
+                    task_id
+                    for task_id, runner_id in task_map.items()
+                    if self.poll_task(runner_id, 0).task_status == TaskRunStatus.FAILED
+                ]
+            )
+            for partition_id, task_map in runner_ids.items()
+        }
 
     def cancel_task(self, runner_id: Dict[str, Any]) -> None:
         # No-op

--- a/pctasks/run/pctasks/run/workflow/executor/models.py
+++ b/pctasks/run/pctasks/run/workflow/executor/models.py
@@ -93,6 +93,7 @@ class TaskState:
         Union[SuccessfulTaskSubmitResult, FailedTaskSubmitResult]
     ] = None
     _task_result: Optional[TaskResult] = None
+    _task_runner_id: Optional[Dict[str, Any]] = None
 
     status_updated: bool = False
     """True if task record has been updated to current status"""
@@ -132,6 +133,10 @@ class TaskState:
     @property
     def task_id(self) -> str:
         return self.prepared_task.task_submit_message.definition.id
+
+    @property
+    def task_runner_id(self) -> Optional[Dict[str, Any]]:
+        return self._task_runner_id
 
     def change_status(self, status: TaskStateStatus) -> bool:
         if not self.status == status:
@@ -213,6 +218,7 @@ class TaskState:
         self._submit_result = submit_result
 
         if isinstance(submit_result, SuccessfulTaskSubmitResult):
+            self._task_runner_id = submit_result.task_runner_id
             self.change_status(TaskStateStatus.SUBMITTED)
         else:
             self.set_failed(submit_result.errors)

--- a/pctasks/run/pctasks/run/workflow/executor/models.py
+++ b/pctasks/run/pctasks/run/workflow/executor/models.py
@@ -359,6 +359,10 @@ class JobPartitionState:
         return self.job_part_submit_msg.job_id
 
     @property
+    def partition_id(self) -> str:
+        return self.job_part_submit_msg.partition_id
+
+    @property
     def run_id(self) -> str:
         return self.job_part_submit_msg.run_id
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -18,7 +18,7 @@ Options:
     --azurite
         Only run the Azurite setup.
     --cosmos
-        Only run the Cosmos Emulator setup.
+        Only run the CosmosDB setup.
     --reset-cosmos
         Reset the CosmosDB emulator.
     --rm-test-containers


### PR DESCRIPTION
This PR:
- Adds a bulk_put method on containers, which allows a stored procedure to do bulk inserts into CosmosDB. This optimizes the creation of JobPartitionRunRecord in remote.py
- Move from polling individual tasks to querying for failed tasks. This puts less pressure on the Azure Batch API for workflows that have many partitions.
- Logs during the create-items tasks to show speed of each individual item creation and progress through the chunk file.