### PR TITLE
[dataset] Fixed ingest --use-existing-chunkset

### DIFF
--- a/pctasks/dataset/pctasks/dataset/chunks/models.py
+++ b/pctasks/dataset/pctasks/dataset/chunks/models.py
@@ -6,6 +6,7 @@ from pctasks.core.models.task import TaskDefinition
 from pctasks.dataset.chunks.constants import (
     ASSET_CHUNKS_PREFIX,
     CREATE_CHUNKS_TASK_PATH,
+    LIST_CHUNKS_TASK_PATH,
 )
 from pctasks.dataset.constants import CREATE_CHUNKS_TASK_ID, LIST_CHUNKS_TASK_ID
 from pctasks.dataset.models import ChunkOptions, CollectionDefinition, DatasetDefinition
@@ -96,13 +97,15 @@ class ListChunksTaskConfig(TaskDefinition):
         cls,
         image: str,
         args: ListChunksInput,
-        task: str = CREATE_CHUNKS_TASK_PATH,
+        task: str = LIST_CHUNKS_TASK_PATH,
+        code: Optional[CodeConfig] = None,
         environment: Optional[Dict[str, str]] = None,
         tags: Optional[Dict[str, str]] = None,
     ) -> "ListChunksTaskConfig":
         return ListChunksTaskConfig(
             id=LIST_CHUNKS_TASK_ID,
             image=image,
+            code=code,
             args=args.dict(),
             task=task,
             environment=environment,
@@ -126,8 +129,9 @@ class ListChunksTaskConfig(TaskDefinition):
 
         return cls.create(
             image=ds.image,
+            code=ds.code,
             args=ListChunksInput(chunkset_uri=chunkset_uri, all=all),
-            task=f"{collection.collection_class}.create_chunks_task",
+            task=LIST_CHUNKS_TASK_PATH,
             environment=environment,
             tags=tags,
         )

--- a/pctasks/dataset/tests/test_dataset.py
+++ b/pctasks/dataset/tests/test_dataset.py
@@ -31,54 +31,58 @@ def test_process_items() -> None:
     ds_config = template_dataset_file(DATASET_PATH)
     collection_config = ds_config.collections[0]
 
-    workflow = create_process_items_workflow(
-        ds_config,
-        collection_config,
-        chunkset_id="test-chunkset",
-        ingest=False,
-        target="test",
-    )
-    assert workflow.target_environment == "test"
-
-    print(workflow.to_yaml())
-
-    tokens = collection_config.get_tokens()
-
     with TemporaryDirectory() as tmp_dir:
         with temp_azurite_blob_storage() as storage:
-            copy_dir_to_azurite(
-                storage, HERE / "data-files" / "simple-assets", prefix="assets"
-            )
-            path = BlobUri(storage.get_uri()).blob_name
-            assert path
-            outputs = SimpleWorkflowExecutor().run_workflow(
-                workflow,
-                output_uri=tmp_dir,
-                args={"test_prefix": path, "sas_token": get_azurite_sas_token()},
-                context=TaskContext(
-                    storage_factory=StorageFactory(tokens=Tokens(tokens)),
-                    run_id="test-dataset-1",
-                ),
-            )
-
-            print(json.dumps(outputs, indent=2))
-
-            ndjson_paths = list(
-                storage.list_files(
-                    name_starts_with="chunks/test-chunkset/items/all",
-                    extensions=[".ndjson"],
+            # Run this twice, once from scratch and once with the
+            # chunkset from the first loop
+            for use_existing_chunks in [False, True]:
+                workflow = create_process_items_workflow(
+                    ds_config,
+                    collection_config,
+                    chunkset_id="test-chunkset",
+                    ingest=False,
+                    target="test",
+                    use_existing_chunks=use_existing_chunks,
                 )
-            )
+                assert workflow.target_environment == "test"
 
-            assert len(ndjson_paths) == 2
+                print(workflow.to_yaml())
 
-            ids: Set[str] = set()
-            for path in ndjson_paths:
-                ndjson = storage.read_text(path)
-                lines = ndjson.splitlines()
-                assert len(lines) == 2
-                for line in lines:
-                    item = orjson.loads(line)
-                    validate_stac(item)
-                    ids.add(item["id"])
-            assert len(ids) == 4
+                tokens = collection_config.get_tokens()
+
+                copy_dir_to_azurite(
+                    storage, HERE / "data-files" / "simple-assets", prefix="assets"
+                )
+                path = BlobUri(storage.get_uri()).blob_name
+                assert path
+                outputs = SimpleWorkflowExecutor().run_workflow(
+                    workflow,
+                    output_uri=tmp_dir,
+                    args={"test_prefix": path, "sas_token": get_azurite_sas_token()},
+                    context=TaskContext(
+                        storage_factory=StorageFactory(tokens=Tokens(tokens)),
+                        run_id="test-dataset-1",
+                    ),
+                )
+
+                print(json.dumps(outputs, indent=2))
+
+                ndjson_paths = list(
+                    storage.list_files(
+                        name_starts_with="chunks/test-chunkset/items/all",
+                        extensions=[".ndjson"],
+                    )
+                )
+
+                assert len(ndjson_paths) == 2
+
+                ids: Set[str] = set()
+                for path in ndjson_paths:
+                    ndjson = storage.read_text(path)
+                    lines = ndjson.splitlines()
+                    assert len(lines) == 2
+                    for line in lines:
+                        item = orjson.loads(line)
+                        validate_stac(item)
+                        ids.add(item["id"])
+                assert len(ids) == 4


### PR DESCRIPTION
## Description

Previously `--use-existing-chunkset` was failing with errors about the task not recieving the right arguments. I think this is because the wrong task name was used.

Fixes #68 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
