### PR TITLE
[dataset/QPE]: Add flag to generate update workflows

### DIFF
--- a/datasets/noaa-mrms-qpe/README.md
+++ b/datasets/noaa-mrms-qpe/README.md
@@ -1,0 +1,39 @@
+# NOAA-MRMS-QPE
+
+This dataset handles https://planetarycomputer.microsoft.com/dataset/group/noaa-mrms-qpe
+
+## Dynamic updates
+
+The update workflows were generated with the following:
+
+```
+pctasks dataset process-items '${{ args.since }}' \
+    -d datasets/noaa-mrms-qpe/dataset.yaml \
+    -c noaa-mrms-qpe-1h-pass1 \
+    --workflow-id=noaa_mrms_qpe-noaa-mrms-qpe-1h-pass1-process-items-update \
+    --target=green \
+    --is-update-workflow \
+    > datasets/noaa-mrms-qpe/workflows/update-noaa-mrms-qpe-1h-pass1.yaml
+
+pctasks dataset process-items '${{ args.since }}' \
+    -d datasets/noaa-mrms-qpe/dataset.yaml \
+    -c noaa-mrms-qpe-1h-pass2 \
+    --workflow-id=noaa_mrms_qpe-noaa-mrms-qpe-1h-pass2-process-items-update \
+    --target=green \
+    --is-update-workflow \
+    > datasets/noaa-mrms-qpe/workflows/update-noaa-mrms-qpe-1h-pass2.yaml
+
+pctasks dataset process-items '${{ args.since }}' \
+    -d datasets/noaa-mrms-qpe/dataset.yaml \
+    -c noaa-mrms-qpe-24h-pass2 \
+    --workflow-id=noaa_mrms_qpe-noaa-mrms-qpe-24h-pass2-process-items-update \
+    --target=green \
+    --is-update-workflow \
+    > datasets/noaa-mrms-qpe/workflows/update-noaa-mrms-qpe-24h-pass2.yaml
+```
+
+They can be registered with
+
+```bash
+$ ls datasets/noaa-mrms-qpe/workflows/* | xargs -I {} pctasks workflow update {}
+```

--- a/datasets/noaa-mrms-qpe/workflows/update-noaa-mrms-qpe-1h-pass1.yaml
+++ b/datasets/noaa-mrms-qpe/workflows/update-noaa-mrms-qpe-1h-pass1.yaml
@@ -1,0 +1,109 @@
+name: Process items for noaa-mrms-qpe-1h-pass1
+tokens:
+  mrms:
+    containers:
+      mrms:
+        token: ${{ pc.get_token(mrms, mrms) }}
+target_environment: green
+args:
+- registry
+- since
+jobs:
+  create-splits:
+    id: create-splits
+    tasks:
+    - id: create-splits
+      image: ${{ args.registry }}/pctasks-task-base:latest
+      code:
+        src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
+        requirements: datasets/noaa-mrms-qpe/requirements.txt
+      task: noaa_mrms_qpe:NoaaMrmsQpeCollection.create_splits_task
+      args:
+        inputs:
+        - uri: blob://mrms/mrms
+          splits:
+          - depth: 1
+          sas_token: ${{ pc.get_token(mrms, mrms) }}
+          chunk_options:
+            chunk_length: 48
+            name_starts_with: MultiSensor_QPE_01H_Pass1_00.00
+            extensions:
+            - .gz
+            list_folders: false
+            chunk_file_name: uris-list
+            chunk_extension: .csv
+            since: ${{ args.since }}
+        options: {}
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+  create-chunks:
+    id: create-chunks
+    tasks:
+    - id: create-chunks
+      image: ${{ args.registry }}/pctasks-task-base:latest
+      code:
+        src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
+        requirements: datasets/noaa-mrms-qpe/requirements.txt
+      task: pctasks.dataset.chunks.task:create_chunks_task
+      args:
+        src_uri: ${{ item.uri }}
+        dst_uri: blob://mrms/mrms-etl-data/qpe-1h-pass1/${{ args.since }}/assets
+        options: ${{ item.chunk_options }}
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+    foreach:
+      items: ${{ jobs.create-splits.tasks.create-splits.output.splits }}
+      flatten: true
+    needs: create-splits
+  process-chunk:
+    id: process-chunk
+    tasks:
+    - id: create-items
+      image: ${{ args.registry }}/pctasks-task-base:latest
+      code:
+        src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
+        requirements: datasets/noaa-mrms-qpe/requirements.txt
+      task: noaa_mrms_qpe:NoaaMrmsQpeCollection.create_items_task
+      args:
+        asset_chunk_info:
+          uri: ${{ item.uri }}
+          chunk_id: ${{ item.chunk_id }}
+        item_chunkset_uri: blob://mrms/mrms-etl-data/qpe-1h-pass1/${{ args.since }}/items
+        collection_id: noaa-mrms-qpe-1h-pass1
+        options:
+          skip_validation: false
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+    - id: ingest-items
+      image_key: ingest
+      task: pctasks.ingest_task.task:ingest_task
+      args:
+        content:
+          type: Ndjson
+          uris:
+          - ${{tasks.create-items.output.ndjson_uri}}
+        options:
+          insert_group_size: 5000
+          insert_only: false
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+    foreach:
+      items: ${{ jobs.create-chunks.tasks.create-chunks.output.chunks }}
+      flatten: true
+    needs: create-chunks
+schema_version: 1.0.0
+id: noaa_mrms_qpe-noaa-mrms-qpe-1h-pass1-process-items-update
+dataset: noaa_mrms_qpe
+

--- a/datasets/noaa-mrms-qpe/workflows/update-noaa-mrms-qpe-1h-pass2.yaml
+++ b/datasets/noaa-mrms-qpe/workflows/update-noaa-mrms-qpe-1h-pass2.yaml
@@ -1,0 +1,109 @@
+name: Process items for noaa-mrms-qpe-1h-pass2
+tokens:
+  mrms:
+    containers:
+      mrms:
+        token: ${{ pc.get_token(mrms, mrms) }}
+target_environment: green
+args:
+- registry
+- since
+jobs:
+  create-splits:
+    id: create-splits
+    tasks:
+    - id: create-splits
+      image: ${{ args.registry }}/pctasks-task-base:latest
+      code:
+        src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
+        requirements: datasets/noaa-mrms-qpe/requirements.txt
+      task: noaa_mrms_qpe:NoaaMrmsQpeCollection.create_splits_task
+      args:
+        inputs:
+        - uri: blob://mrms/mrms
+          splits:
+          - depth: 1
+          sas_token: ${{ pc.get_token(mrms, mrms) }}
+          chunk_options:
+            chunk_length: 48
+            name_starts_with: MultiSensor_QPE_01H_Pass2_00.00
+            extensions:
+            - .gz
+            list_folders: false
+            chunk_file_name: uris-list
+            chunk_extension: .csv
+            since: ${{ args.since }}
+        options: {}
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+  create-chunks:
+    id: create-chunks
+    tasks:
+    - id: create-chunks
+      image: ${{ args.registry }}/pctasks-task-base:latest
+      code:
+        src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
+        requirements: datasets/noaa-mrms-qpe/requirements.txt
+      task: pctasks.dataset.chunks.task:create_chunks_task
+      args:
+        src_uri: ${{ item.uri }}
+        dst_uri: blob://mrms/mrms-etl-data/qpe-1h-pass2/${{ args.since }}/assets
+        options: ${{ item.chunk_options }}
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+    foreach:
+      items: ${{ jobs.create-splits.tasks.create-splits.output.splits }}
+      flatten: true
+    needs: create-splits
+  process-chunk:
+    id: process-chunk
+    tasks:
+    - id: create-items
+      image: ${{ args.registry }}/pctasks-task-base:latest
+      code:
+        src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
+        requirements: datasets/noaa-mrms-qpe/requirements.txt
+      task: noaa_mrms_qpe:NoaaMrmsQpeCollection.create_items_task
+      args:
+        asset_chunk_info:
+          uri: ${{ item.uri }}
+          chunk_id: ${{ item.chunk_id }}
+        item_chunkset_uri: blob://mrms/mrms-etl-data/qpe-1h-pass2/${{ args.since }}/items
+        collection_id: noaa-mrms-qpe-1h-pass2
+        options:
+          skip_validation: false
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+    - id: ingest-items
+      image_key: ingest
+      task: pctasks.ingest_task.task:ingest_task
+      args:
+        content:
+          type: Ndjson
+          uris:
+          - ${{tasks.create-items.output.ndjson_uri}}
+        options:
+          insert_group_size: 5000
+          insert_only: false
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+    foreach:
+      items: ${{ jobs.create-chunks.tasks.create-chunks.output.chunks }}
+      flatten: true
+    needs: create-chunks
+schema_version: 1.0.0
+id: noaa_mrms_qpe-noaa-mrms-qpe-1h-pass2-process-items-update
+dataset: noaa_mrms_qpe
+

--- a/datasets/noaa-mrms-qpe/workflows/update-noaa-mrms-qpe-24h-pass2.yaml
+++ b/datasets/noaa-mrms-qpe/workflows/update-noaa-mrms-qpe-24h-pass2.yaml
@@ -1,0 +1,110 @@
+name: Process items for noaa-mrms-qpe-24h-pass2
+tokens:
+  mrms:
+    containers:
+      mrms:
+        token: ${{ pc.get_token(mrms, mrms) }}
+target_environment: green
+args:
+- registry
+- since
+jobs:
+  create-splits:
+    id: create-splits
+    tasks:
+    - id: create-splits
+      image: ${{ args.registry }}/pctasks-task-base:latest
+      code:
+        src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
+        requirements: datasets/noaa-mrms-qpe/requirements.txt
+      task: noaa_mrms_qpe:NoaaMrmsQpeCollection.create_splits_task
+      args:
+        inputs:
+        - uri: blob://mrms/mrms
+          splits:
+          - depth: 1
+          sas_token: ${{ pc.get_token(mrms, mrms) }}
+          chunk_options:
+            chunk_length: 48
+            name_starts_with: MultiSensor_QPE_24H_Pass2_00.00
+            extensions:
+            - .gz
+            list_folders: false
+            chunk_file_name: uris-list
+            chunk_extension: .csv
+            since: ${{ args.since }}
+        options: {}
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+  create-chunks:
+    id: create-chunks
+    tasks:
+    - id: create-chunks
+      image: ${{ args.registry }}/pctasks-task-base:latest
+      code:
+        src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
+        requirements: datasets/noaa-mrms-qpe/requirements.txt
+      task: pctasks.dataset.chunks.task:create_chunks_task
+      args:
+        src_uri: ${{ item.uri }}
+        dst_uri: blob://mrms/mrms-etl-data/qpe-24h-pass2/${{ args.since }}/assets
+        options: ${{ item.chunk_options }}
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+    foreach:
+      items: ${{ jobs.create-splits.tasks.create-splits.output.splits }}
+      flatten: true
+    needs: create-splits
+  process-chunk:
+    id: process-chunk
+    tasks:
+    - id: create-items
+      image: ${{ args.registry }}/pctasks-task-base:latest
+      code:
+        src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
+        requirements: datasets/noaa-mrms-qpe/requirements.txt
+      task: noaa_mrms_qpe:NoaaMrmsQpeCollection.create_items_task
+      args:
+        asset_chunk_info:
+          uri: ${{ item.uri }}
+          chunk_id: ${{ item.chunk_id }}
+        item_chunkset_uri: blob://mrms/mrms-etl-data/qpe-24h-pass2/${{ args.since
+          }}/items
+        collection_id: noaa-mrms-qpe-24h-pass2
+        options:
+          skip_validation: false
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+    - id: ingest-items
+      image_key: ingest
+      task: pctasks.ingest_task.task:ingest_task
+      args:
+        content:
+          type: Ndjson
+          uris:
+          - ${{tasks.create-items.output.ndjson_uri}}
+        options:
+          insert_group_size: 5000
+          insert_only: false
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+    foreach:
+      items: ${{ jobs.create-chunks.tasks.create-chunks.output.chunks }}
+      flatten: true
+    needs: create-chunks
+schema_version: 1.0.0
+id: noaa_mrms_qpe-noaa-mrms-qpe-24h-pass2-process-items-update
+dataset: noaa_mrms_qpe
+

--- a/docs/getting_started/creating_a_dataset.md
+++ b/docs/getting_started/creating_a_dataset.md
@@ -282,3 +282,21 @@ Also note that, because our dataset has multiple collections, you need to pass i
 option is not required. The `--submit` option will submit the generated workflow to PCTasks;
 if not supplied, then the workflow will be printed to stdout, which can be submitted later through
 the `pctasks workflow submit` command.
+
+## Dynamic updates
+
+You generate a workflow from a `dataset.yaml` to use in dynamic updates with the
+`--is-update-workflow` flag to `pctasks dataset`. This will append a `--since` argument
+to the workflow's `args`.
+
+You can register the generated workflow with pctasks:
+
+```shell
+> pctasks workflow update ...
+```
+
+And then set up a cron job or some other system to call it, providing `--since` as an arguemnt
+
+```shell
+> pctasks workflow submit ... --arg since $(date -d '-1 day' '+%Y-%m-%dT%H:%M:%S')
+```

--- a/pctasks/dataset/pctasks/dataset/_cli.py
+++ b/pctasks/dataset/pctasks/dataset/_cli.py
@@ -99,6 +99,7 @@ def process_items_cmd(
     submit: bool = False,
     upsert: bool = False,
     workflow_id: Optional[str] = None,
+    is_update_workflow: bool = False,
 ) -> None:
     """Generate the workflow to create and ingest items.
 
@@ -138,6 +139,7 @@ def process_items_cmd(
         ingest_options=None,
         target=target,
         tags=None,
+        is_update_workflow=is_update_workflow,
     )
 
     cli_handle_workflow(

--- a/pctasks/dataset/pctasks/dataset/cli.py
+++ b/pctasks/dataset/pctasks/dataset/cli.py
@@ -105,7 +105,9 @@ def create_chunks_cmd(
     help=("Only process files that have been modified at or after this datetime."),
 )
 @click.option(
-    "--is-update-workflow", is_flag=True, help="",
+    "--is-update-workflow",
+    is_flag=True,
+    help="Make an 'update' workflow by adding 'since' to the runtime arguments.",
 )
 @opt_submit
 @opt_upsert

--- a/pctasks/dataset/pctasks/dataset/cli.py
+++ b/pctasks/dataset/pctasks/dataset/cli.py
@@ -104,6 +104,9 @@ def create_chunks_cmd(
     "--since",
     help=("Only process files that have been modified at or after this datetime."),
 )
+@click.option(
+    "--is-update-workflow", is_flag=True, help="",
+)
 @opt_submit
 @opt_upsert
 @opt_workflow_id
@@ -122,6 +125,7 @@ def process_items_cmd(
     submit: bool = False,
     upsert: bool = False,
     workflow_id: Optional[str] = None,
+    is_update_workflow: bool = False,
 ) -> None:
     """Generate the workflow to create and ingest items.
 
@@ -152,6 +156,7 @@ def process_items_cmd(
         submit=submit,
         upsert=upsert,
         workflow_id=workflow_id,
+        is_update_workflow=is_update_workflow,
     )
 
 

--- a/pctasks/dataset/pctasks/dataset/workflow.py
+++ b/pctasks/dataset/pctasks/dataset/workflow.py
@@ -210,7 +210,10 @@ def create_process_items_workflow(
     )
 
     if is_update_workflow:
-        workflow_definition.args.append("since")
+        if workflow_definition.args is None:
+            workflow_definition = workflow_definition.copy(update={"args": ["since"]})
+        else:
+            workflow_definition.args.append("since")
         workflow_definition.jobs["create-splits"].tasks[0].args["inputs"][0][
             "chunk_options"
         ]["since"] = "${{ args.since }}"

--- a/pctasks/dataset/pctasks/dataset/workflow.py
+++ b/pctasks/dataset/pctasks/dataset/workflow.py
@@ -93,6 +93,7 @@ def create_process_items_workflow(
     ingest_options: Optional[IngestOptions] = None,
     target: Optional[str] = None,
     tags: Optional[Dict[str, str]] = None,
+    is_update_workflow: bool = False,
 ) -> WorkflowDefinition:
 
     chunks_job_id: str
@@ -195,7 +196,7 @@ def create_process_items_workflow(
     id = f"{collection.id}-process-items"
     if collection.id != dataset.id:
         id = f"{dataset.id}-{id}"
-    return WorkflowDefinition(
+    workflow_definition = WorkflowDefinition(
         id=id,
         name=f"Process items for {collection.id}",
         dataset=dataset.id,
@@ -207,6 +208,14 @@ def create_process_items_workflow(
         },
         target_environment=target,
     )
+
+    if is_update_workflow:
+        workflow_definition.args.append("since")
+        workflow_definition.jobs["create-splits"].tasks[0].args["inputs"][0][
+            "chunk_options"
+        ]["since"] = "${{ args.since }}"
+
+    return workflow_definition
 
 
 def create_ingest_collection_workflow(

--- a/pctasks/dataset/tests/test_dataset.py
+++ b/pctasks/dataset/tests/test_dataset.py
@@ -82,3 +82,24 @@ def test_process_items() -> None:
                     validate_stac(item)
                     ids.add(item["id"])
             assert len(ids) == 4
+
+
+def test_process_items_is_update_workflow() -> None:
+    ds_config = template_dataset_file(DATASET_PATH)
+    collection_config = ds_config.collections[0]
+
+    workflow = create_process_items_workflow(
+        ds_config,
+        collection_config,
+        chunkset_id="${{ args.since }}",
+        ingest=False,
+        target="test",
+        is_update_workflow=True,
+    )
+    assert "since" in workflow.args
+    assert (
+        workflow.jobs["create-splits"]
+        .tasks[0]
+        .args["inputs"][0]["chunk_options"]["since"]
+        == "${{ args.since }}"
+    )

--- a/pctasks/dataset/tests/test_dataset.py
+++ b/pctasks/dataset/tests/test_dataset.py
@@ -5,6 +5,7 @@ from tempfile import TemporaryDirectory
 from typing import Set
 
 import orjson
+import pytest
 
 from pctasks.cli.cli import setup_logging
 from pctasks.core.storage import StorageFactory
@@ -84,8 +85,13 @@ def test_process_items() -> None:
             assert len(ids) == 4
 
 
-def test_process_items_is_update_workflow() -> None:
+@pytest.mark.parametrize("has_args", [True, False])
+def test_process_items_is_update_workflow(has_args) -> None:
     ds_config = template_dataset_file(DATASET_PATH)
+    if not has_args:
+        ds_config = ds_config.copy(update={"args": None})
+        assert ds_config.args is None
+
     collection_config = ds_config.collections[0]
 
     workflow = create_process_items_workflow(


### PR DESCRIPTION
This is a bit of a hack, but it's a relatively small change to generate an "update" workflow from a dataset.yaml.

When you pass `--is-update`, this will

1. Append a `--since` argument to the workflow arguments
2. Inject the string literal `"${{ args.since }}"` for the `since` argument to the create-splits task. Then, when the update is later run with a concrete `--since` that concrete value will be templated in.

Combine that with a chunkset ID that also contains the literal `${{ args.since }}` and I think we have everything we need for dynamic updates.

This PR includes update workflows for noaa-mrms-qpe as an example.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

`pctasks workflow submit noaa_mrms_qpe-noaa-mrms-qpe-1h-pass1-process-items-update --arg registry pccomponentstest.azurecr.io --arg since ${SINCE}`

## Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)