### PR TITLE
[WIP] Add command to rerun a single chunkset

### DIFF
--- a/datasets/goes/goes-glm/dataset.yaml
+++ b/datasets/goes/goes-glm/dataset.yaml
@@ -1,5 +1,5 @@
 id: goes_glm
-image: ${{ args.registry }}/pctasks-goes-glm:2022.10.31.0
+image: ${{ args.registry }}/pctasks-goes-glm:2022.11.3.0
 
 args:
 - registry

--- a/datasets/goes/goes-glm/goes_glm.py
+++ b/datasets/goes/goes-glm/goes_glm.py
@@ -47,7 +47,7 @@ class GoesGlmCollection(Collection):
                 # https://goeseuwest.blob.core.windows.net/noaa-goes17/GLM-L2-LCFA/2021/088/21/OR_GLM-L2-LCFA_G17_s20210882130200_e20210882130404_c20210882130418.nc   # noqa: E501
                 # last modified at 2021-09-02T13:15:26.000Z
                 logger.exception("Possibly invalid NetCDF file at %s", asset_uri)
-                # TODO: need some mechanism for signaling ignore this.
+                # TODO: need some mechanism for signaling ignore this?
                 raise
 
         # preference: slim down the source netcdf asset

--- a/pctasks/dataset/pctasks/dataset/_cli.py
+++ b/pctasks/dataset/pctasks/dataset/_cli.py
@@ -11,7 +11,11 @@ from pctasks.core.utils import map_opt
 from pctasks.core.yaml import YamlValidationError
 from pctasks.dataset.chunks.models import ChunkOptions
 from pctasks.dataset.constants import DEFAULT_DATASET_YAML_PATH
-from pctasks.dataset.models import MultipleCollectionsError
+from pctasks.dataset.models import (
+    MultipleCollectionsError,
+    DatasetDefinition,
+    CollectionDefinition,
+)
 from pctasks.dataset.splits.models import CreateSplitsOptions
 from pctasks.dataset.template import template_dataset_file
 from pctasks.dataset.workflow import (
@@ -86,7 +90,9 @@ def create_chunks_cmd(
     )
 
 
-def _configs_from_cli(dataset: Optional[str], arg: List[Tuple[str, str]], collection: Optional[str]):
+def _configs_from_cli(
+    dataset: Optional[str], arg: List[Tuple[str, str]], collection: Optional[str]
+) -> Tuple[DatasetDefinition, CollectionDefinition]:
     try:
         ds_config = template_dataset_file(dataset, dict(arg))
     except (MarkedYAMLError, YamlValidationError) as e:
@@ -106,7 +112,6 @@ def _configs_from_cli(dataset: Optional[str], arg: List[Tuple[str, str]], collec
     return ds_config, collection_config
 
 
-
 def reprocess_chunkset_cmd(
     ctx: click.Context,
     chunk_id: str,
@@ -119,7 +124,7 @@ def reprocess_chunkset_cmd(
     submit: bool = False,
     upsert: bool = False,
     workflow_id: Optional[str] = None,
-):
+) -> None:
     arg = arg or []
     ds_config, collection_config = _configs_from_cli(dataset, arg, collection)
 
@@ -275,5 +280,3 @@ def list_collections_cmd(
 
     for collection in ds_config.collections:
         cli_output(collection.id)
-
-

--- a/pctasks/dataset/pctasks/dataset/cli.py
+++ b/pctasks/dataset/pctasks/dataset/cli.py
@@ -162,6 +162,63 @@ def process_items_cmd(
     )
 
 
+@click.command("reprocess-chunkset", help="""\
+Generate a workflow for re-running a chunkset from a process-items task.
+
+``chunkset_id`` controls where the output items are written. Use the
+same chunkset ID as from `process-items` to write to the same location.
+
+``asset-uri`` should be the pctasks style URI to `uris-list.csv` file. For
+example::
+
+blob://<account>/<container>/pctasks/<prefix>/assets/all/<chunkset_id>/uris-list.csv.
+""")
+@click.argument("chunkset_id")
+@click.argument("asset-uri")
+@opt_ds_config
+@opt_collection
+@opt_args
+@click.option(
+    "-t",
+    "--target",
+    help="The target environment to process the items in.",
+)
+@click.option("--no-ingest", is_flag=True, help="Create ndjsons, but don't ingest.")
+@opt_submit
+@opt_upsert
+@opt_workflow_id
+@click.pass_context
+def reprocess_chunkset_cmd(
+    ctx: click.Context,
+    chunkset_id: str,
+    asset_uri: str,
+    dataset: Optional[str],
+    collection: Optional[str],
+    arg: List[Tuple[str, str]] = [],
+    target: Optional[str] = None,
+    no_ingest: bool = False,
+    submit: bool = False,
+    upsert: bool = False,
+    workflow_id: Optional[str] = None,
+) -> None:
+    """"""
+    from . import _cli
+
+    return _cli.reprocess_chunkset_cmd(
+        ctx,
+        chunkset_id,
+        asset_uri,
+        dataset,
+        collection,
+        arg=arg,
+        target=target,
+        no_ingest=no_ingest,
+        submit=submit,
+        upsert=upsert,
+        workflow_id=workflow_id,
+    )
+
+
 @click.command("ingest-collection")
 @opt_ds_config
 @opt_collection
@@ -227,7 +284,9 @@ def list_collections_cmd(
     return _cli.list_collections_cmd(ctx, dataset, arg=arg)
 
 
+
 dataset_cmd.add_command(create_chunks_cmd)
 dataset_cmd.add_command(process_items_cmd)
+dataset_cmd.add_command(reprocess_chunkset_cmd)
 dataset_cmd.add_command(ingest_collection_cmd)
 dataset_cmd.add_command(list_collections_cmd)

--- a/pctasks/dataset/pctasks/dataset/items/task.py
+++ b/pctasks/dataset/pctasks/dataset/items/task.py
@@ -27,7 +27,7 @@ class CreateItemsMultiError(Exception):
         self.asset_uris = asset_uris
         self.rendered_tracebacks = rendered_tracebacks
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         n = len(self.asset_uris)
         if n:
             sample_asset_uri = self.asset_uris[0]
@@ -130,7 +130,6 @@ class CreateItemsTask(Task[CreateItemsInput, CreateItemsOutput]):
                 )
             except Exception as e:
                 logger.exception("Failed to create item from %s", args.asset_uri)
-                exceptions.append()
                 raise CreateItemsError(
                     f"Failed to create item from {args.asset_uri}"
                 ) from e
@@ -179,7 +178,7 @@ class CreateItemsTask(Task[CreateItemsInput, CreateItemsOutput]):
                         results.extend(result)
             if exceptions and raise_exceptions:
                 asset_uris, rendered_tracebacks = zip(*exceptions)
-                raise CreateItemsMultiError(asset_uris, rendered_tracebacks)
+                raise CreateItemsMultiError(list(asset_uris), list(rendered_tracebacks))
 
         else:
             # Should be prevented by validator

--- a/pctasks/dataset/pctasks/dataset/items/task.py
+++ b/pctasks/dataset/pctasks/dataset/items/task.py
@@ -3,7 +3,7 @@ import os
 import textwrap
 import time
 import traceback
-from typing import Callable, List, Tuple, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 import orjson
 import pystac
@@ -29,6 +29,8 @@ class CreateItemsMultiError(Exception):
 
     def __repr__(self) -> str:
         n = len(self.asset_uris)
+        sample_asset_uri: Optional[str]
+        sample_traceback: Optional[str]
         if n:
             sample_asset_uri = self.asset_uris[0]
             sample_traceback = self.rendered_tracebacks[0]

--- a/pctasks/dataset/pctasks/dataset/items/task.py
+++ b/pctasks/dataset/pctasks/dataset/items/task.py
@@ -35,9 +35,10 @@ class CreateItemsMultiError(Exception):
         else:
             sample_asset_uri = sample_traceback = None
 
-        return textwrap.dedent("""\
+        return textwrap.dedent(
+            """\
         {n} failures during item creation.
-        
+
         Sample asset uri:
 
             {sample_asset_uri}
@@ -45,7 +46,11 @@ class CreateItemsMultiError(Exception):
         Sample traceback:
 
             {sample_traceback}
-        """).format(n=n, sample_asset_uri=sample_asset_uri, sample_traceback=sample_traceback)
+        """
+        ).format(
+            n=n, sample_asset_uri=sample_asset_uri, sample_traceback=sample_traceback
+        )
+
 
 CreateItemFunc = Callable[
     [str, StorageFactory], Union[List[pystac.Item], WaitTaskResult]

--- a/pctasks/dataset/pctasks/dataset/items/task.py
+++ b/pctasks/dataset/pctasks/dataset/items/task.py
@@ -78,6 +78,7 @@ class CreateItemsTask(Task[CreateItemsInput, CreateItemsOutput]):
         storage_factory = context.storage_factory
         results: List[pystac.Item] = []
         exceptions: List[Tuple[str, str]] = []
+        raise_exceptions = False
 
         def _validate(items: List[pystac.Item]) -> None:
             if not args.options.skip_validation:
@@ -167,7 +168,7 @@ class CreateItemsTask(Task[CreateItemsInput, CreateItemsOutput]):
                         _validate(result)
                         _ensure_collection(result)
                         results.extend(result)
-            if exceptions:
+            if exceptions and raise_exceptions:
                 asset_uris, rendered_tracebacks = zip(*exceptions)
                 raise CreateItemsMultiError(asset_uris, rendered_tracebacks)
 

--- a/pctasks/dataset/pctasks/dataset/workflow.py
+++ b/pctasks/dataset/pctasks/dataset/workflow.py
@@ -91,7 +91,7 @@ def create_reprocess_chunkset_workflow(
     ingest_options: Optional[IngestOptions] = None,
     target: Optional[str] = None,
     tags: Optional[Dict[str, str]] = None,
-):
+) -> WorkflowDefinition:
     items_tasks: List[TaskDefinition] = []
 
     asset_chunk_info=ChunkInfo(

--- a/pctasks/dataset/pctasks/dataset/workflow.py
+++ b/pctasks/dataset/pctasks/dataset/workflow.py
@@ -134,7 +134,7 @@ def create_reprocess_chunkset_workflow(
         # ),
     )
 
-    id = f"{collection.id}-reprocess-items"
+    id = f"{collection.id}-reprocess-chunkset"
     if collection.id != dataset.id:
         id = f"{dataset.id}-{id}"
     workflow_definition = WorkflowDefinition(

--- a/pctasks/dataset/tests/items/test_task.py
+++ b/pctasks/dataset/tests/items/test_task.py
@@ -89,3 +89,7 @@ def test_wait_for_assets():
 
     task_result = run_test_task(args.dict(), TASK_PATH)
     assert isinstance(task_result, WaitTaskResult)
+
+
+def test_deduplicate_items():
+    ...


### PR DESCRIPTION
## Description

Two changes:

1. 86128b6685b9a22664ae108de28b3de2217b53e4

Adds a `pctsaks dataset reprocess-chunkset` command. This might be helpful for reprocessing a chunkset that previously failed for a transient issue (e.g. a node being preempted)

```console
$ pctasks dataset reprocess-chunkset "goeseuwest/noaa-goes16/GLM-L2-LCFA/2022/54/uris-list.csv" "blob://goeseuwest/noaa-goes-etl-data/pctasks/glm/2022.11.02.0-full/assets/all/goeseuwest/noaa-goes16/GLM-L2-LCFA/2022/54/uris-list.csv" -d datasets/goes/goes-glm/dataset.yaml --target=green --arg registry pccomponentstest.azurecr.io -su
```

2. f72d948c88bf19835a1fe59cbd1a96d2c1a0ce4f

Processes all items in a chunkset, rather than halting at the first failure. If there are any failures, they're reraised at the end and the task still fails.
