### PR TITLE
Specify the batch pool id through task tags defined in a dataset yaml file

### DIFF
--- a/deployment/terraform/dev/pools.tf
+++ b/deployment/terraform/dev/pools.tf
@@ -49,3 +49,28 @@ module "batch_pool_d3_v3_ingest" {
 
   subnet_id = module.resources.batch_nodepool_subnet
 }
+
+module "batch_pool_d3_v3_high_memory" {
+  source = "../batch_pool"
+
+  name                = "high_memory_pool"
+  resource_group_name = module.resources.resource_group
+  account_name        = module.resources.batch_account_name
+  display_name        = "2-core 16GiB"
+  vm_size             = "STANDARD_E2_V3"
+  max_tasks_per_node  = 1
+
+  min_dedicated = 0
+  max_dedicated = 0
+
+  min_low_priority = var.min_low_priority
+  max_low_priority = 1
+
+  max_increase_per_scale = 1
+
+  acr_name = var.task_acr_name
+  acr_client_id = var.task_acr_sp_client_id
+  acr_client_secret = var.task_acr_sp_client_secret
+
+  subnet_id = module.resources.batch_nodepool_subnet
+}

--- a/deployment/terraform/staging/pools.tf
+++ b/deployment/terraform/staging/pools.tf
@@ -49,3 +49,28 @@ module "batch_pool_d3_v3_ingest" {
 
   subnet_id = module.resources.batch_nodepool_subnet
 }
+
+module "batch_pool_d3_v3_high_memory" {
+  source = "../batch_pool"
+
+  name                = "high_memory_pool"
+  resource_group_name = module.resources.resource_group
+  account_name        = module.resources.batch_account_name
+  display_name        = "2-core 16GiB"
+  vm_size             = "STANDARD_E2_V3"
+  max_tasks_per_node  = 1
+
+  min_dedicated = 0
+  max_dedicated = 0
+
+  min_low_priority = var.min_low_priority
+  max_low_priority = 1
+
+  max_increase_per_scale = 1
+
+  acr_name = var.task_acr_name
+  acr_client_id = var.task_acr_sp_client_id
+  acr_client_secret = var.task_acr_sp_client_secret
+
+  subnet_id = module.resources.batch_nodepool_subnet
+}

--- a/docs/getting_started/creating_a_dataset.md
+++ b/docs/getting_started/creating_a_dataset.md
@@ -122,6 +122,19 @@ The `environment` provides the ability to inject environment variables into each
 of whether they will be utilized in any specific task. In this case, the variable values are using the `${{ secrets.* }}` template
 group to retrieve secret values. See [](../user_guide/secrets) for more details about secrets.
 
+### task_config
+
+Although not included in the example being reviewed here, custom task-level configurations can be defined in a `task_config` section. Currently, only the assignment of tags to tasks is supported. For example, to specify that the high memory Azure batch pool should be used for the `create-items` task, we can define an appropriate tag on the `create-items` task by adding the following section to the `dataset.yaml` file:
+
+```yaml
+task_config:
+  create-items:
+    tags:
+      batch_pool_id: high_memory_pool
+```
+
+Note that should a conflict occur between a tag generated in code and one defined in the `task_config` section of the `dataset.yaml` file, the `task_config` tag value will take precedence.
+
 ### collections
 
 The `collections` element is a list of collection configuration. If your dataset only has one collection,

--- a/pctasks/dataset/pctasks/dataset/models.py
+++ b/pctasks/dataset/pctasks/dataset/models.py
@@ -152,6 +152,7 @@ class DatasetDefinition(PCBaseModel):
     collections: List[CollectionDefinition]
     args: Optional[List[str]] = None
     environment: Optional[Dict[str, Any]] = None
+    task_config: Optional[Dict[str, Any]] = None
 
     def get_collection(
         self, collection_id: Optional[str] = None

--- a/pctasks/dataset/pctasks/dataset/workflow.py
+++ b/pctasks/dataset/pctasks/dataset/workflow.py
@@ -24,7 +24,24 @@ def task_tags(
     tags: Optional[Dict[str, str]],
     task_config: Optional[Dict[str, Any]],
 ) -> Optional[Dict[str, str]]:
+    """
+    Extracts task-specific tags from the task_config dictionary defined in a
+    dataset.yaml and merges them with any tags directly passed to a workflow
+    creation function. If there is a conflict between tags (same key), the
+    task_config tags (those defined in a dataset.yaml) will take precedence.
 
+    Args:
+        task_name (str): Workflow task id.
+        tags (Optional[Dict[str, str]]): A dictionary of tags that was passed
+            directly to one of the create workflow functions, e.g., via the
+            `tags` parameter in the `create_chunks_workflow` function.
+        task_config (Optional[Dict[str, Any]]): A dictionary of task
+            configuration objects, one of which may be a 'tags' object,
+            originally defined in a dataset.yaml file.
+
+    Returns:
+        Optional[Dict[str, str]]: A merged dictionary of tag key value pairs.
+    """
     task_config_ = {} if task_config is None else task_config
     tags_ = {} if tags is None else tags
     merged_tags = {**tags_, **task_config_.get(task_name, {}).get("tags", {})}

--- a/pctasks/dataset/pctasks/dataset/workflow.py
+++ b/pctasks/dataset/pctasks/dataset/workflow.py
@@ -42,8 +42,8 @@ def task_tags(
     Returns:
         Optional[Dict[str, str]]: A merged dictionary of tag key value pairs.
     """
-    task_config_ = {} if task_config is None else task_config
-    tags_ = {} if tags is None else tags
+    task_config_ = task_config or {}
+    tags_ = tags or {}
     merged_tags = {**tags_, **task_config_.get(task_name, {}).get("tags", {})}
     if merged_tags:
         return merged_tags

--- a/pctasks/dataset/pctasks/dataset/workflow.py
+++ b/pctasks/dataset/pctasks/dataset/workflow.py
@@ -27,7 +27,7 @@ def task_tags(
 
     task_config_ = {} if task_config is None else task_config
     tags_ = {} if tags is None else tags
-    merged_tags = tags_ | task_config_.get(task_name, {}).get("tags", {})
+    merged_tags = {**tags_, **task_config_.get(task_name, {}).get("tags", {})}
     if merged_tags:
         return merged_tags
     else:

--- a/pctasks/dataset/tests/data-files/datasets/test-dataset.yaml
+++ b/pctasks/dataset/tests/data-files/datasets/test-dataset.yaml
@@ -7,6 +7,14 @@ args:
   - test_prefix
   - sas_token
 
+task_config:
+  create-items:
+    tags:
+      batch_pool_id: high_memory_pool
+  ingest-collection:
+    tags:
+      batch_pool_id: ingest_pool
+
 collections:
   - id: test-dataset
     class: mycode:TestCollection

--- a/pctasks/dataset/tests/test_dataset.py
+++ b/pctasks/dataset/tests/test_dataset.py
@@ -113,3 +113,30 @@ def test_process_items_is_update_workflow(has_args) -> None:
         .args["inputs"][0]["chunk_options"]["since"]
         == "${{ args.since }}"
     )
+
+
+def test_task_config_tags() -> None:
+    ds_config = template_dataset_file(DATASET_PATH)
+    assert (
+        ds_config.task_config["create-items"]["tags"]["batch_pool_id"]
+        == "high_memory_pool"
+    )
+    assert (
+        ds_config.task_config["ingest-collection"]["tags"]["batch_pool_id"]
+        == "ingest_pool"
+    )
+
+    collection_config = ds_config.collections[0]
+
+    workflow = create_process_items_workflow(
+        ds_config,
+        collection_config,
+        chunkset_id="test",
+        tags={"tag": "value", "batch_pool_id": "overwritten"},
+    )
+
+    assert workflow.jobs["process-chunk"].tasks[0].tags["tag"] == "value"
+    assert (
+        workflow.jobs["process-chunk"].tasks[0].tags["batch_pool_id"]
+        == "high_memory_pool"
+    )


### PR DESCRIPTION
## Description

Adds a `task_config` dictionary to the `DatasetDefinition` model to enable adding tags to tasks. The tags are parsed from the `task_config` dictionary and added to the appropriate tasks during workflow creation.

The tags are defined in a `task_config` object in the dataset yaml files. For example, a `batch_pool_id` tag can be added to the `create-items` task of a workflow by adding the following to the dataset yaml:

```
task_config:
  create-items:
    tags:
      batch_pool_id: high_memory_pool
```

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

Added a tests to verify that tags specified in a dataset yaml are added to the `DataseDefinition` class and the appropriate workflow tasks.

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)