### PR TITLE
Add collection identifier to dataset.yaml task configurations

### DIFF
--- a/docs/getting_started/creating_a_dataset.md
+++ b/docs/getting_started/creating_a_dataset.md
@@ -124,13 +124,14 @@ group to retrieve secret values. See [](../user_guide/templating.md#secrets) for
 
 ### task_config
 
-Although not included in the example being reviewed here, custom task-level configurations can be defined in a `task_config` section. Currently, only the assignment of tags to tasks is supported. For example, to specify that the high memory Azure batch pool should be used for the `create-items` task, we can define an appropriate tag on the `create-items` task by adding the following section to the `dataset.yaml` file:
+Although not included in the example being reviewed here, custom task-level configurations specific to one of the collections defined in the `dataset.yaml` file can be defined in a `task_config` section. Currently, only the assignment of tags to tasks is supported. For example, to specify that the high memory Azure batch pool should be used for the `create-items` task for the `chesapeake-lc-13` collection, we can define an appropriate tag on the `create-items` task for that collection by adding the following section to the `dataset.yaml` file:
 
 ```yaml
 task_config:
-  create-items:
-    tags:
-      batch_pool_id: high_memory_pool
+  chesapeake-lc-13:
+    create-items:
+      tags:
+        batch_pool_id: high_memory_pool
 ```
 
 Note that should a conflict occur between a tag generated in code and one defined in the `task_config` section of the `dataset.yaml` file, the `task_config` tag value will take precedence.

--- a/pctasks/dataset/tests/data-files/datasets/test-dataset.yaml
+++ b/pctasks/dataset/tests/data-files/datasets/test-dataset.yaml
@@ -8,12 +8,13 @@ args:
   - sas_token
 
 task_config:
-  create-items:
-    tags:
-      batch_pool_id: high_memory_pool
-  ingest-collection:
-    tags:
-      batch_pool_id: ingest_pool
+  test-dataset:
+    create-items:
+      tags:
+        batch_pool_id: high_memory_pool
+    ingest-collection:
+      tags:
+        batch_pool_id: ingest_pool
 
 collections:
   - id: test-dataset

--- a/pctasks/dataset/tests/test_dataset.py
+++ b/pctasks/dataset/tests/test_dataset.py
@@ -118,11 +118,11 @@ def test_process_items_is_update_workflow(has_args) -> None:
 def test_task_config_tags() -> None:
     ds_config = template_dataset_file(DATASET_PATH)
     assert (
-        ds_config.task_config["create-items"]["tags"]["batch_pool_id"]
+        ds_config.task_config["test-dataset"]["create-items"]["tags"]["batch_pool_id"]
         == "high_memory_pool"
     )
     assert (
-        ds_config.task_config["ingest-collection"]["tags"]["batch_pool_id"]
+        ds_config.task_config["test-dataset"]["ingest-collection"]["tags"]["batch_pool_id"]
         == "ingest_pool"
     )
 


### PR DESCRIPTION
## Description

Updates the new task configurations defined in dataset.yaml files to include the collection id. The need for this became apparent when using the new `task_config` in the NOAA Climate Normals dataset.yaml where we wanted to define a tag for a task, but only for one of the three collections.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

The [`test_task_config_tags` test](https://github.com/microsoft/planetary-computer-tasks/blob/23bb218066a2f371ece87e7a7db9f1c5758db991/pctasks/dataset/tests/test_dataset.py#L118) was updated and passes.

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [x] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)