### PR TITLE
[deploy] Make batch accounts private

### DIFF
--- a/deployment/terraform/dev/pools.tf
+++ b/deployment/terraform/dev/pools.tf
@@ -99,3 +99,28 @@ module "batch_pool_d3_v3_landsat" {
 
   subnet_id = module.resources.batch_nodepool_subnet
 }
+
+module "batch_pool_d3_v3_s2" {
+  source = "../batch_pool"
+
+  name                = "s2_pool"
+  resource_group_name = module.resources.resource_group
+  account_name        = module.resources.batch_account_name
+  display_name        = "s2_pool"
+  vm_size             = "STANDARD_D3_V2"
+  max_tasks_per_node  = 4
+
+  min_dedicated = 0
+  max_dedicated = 0
+
+  min_low_priority = var.min_low_priority
+  max_low_priority = 2
+
+  max_increase_per_scale = 50
+
+  acr_name = var.task_acr_name
+  acr_client_id = var.task_acr_sp_client_id
+  acr_client_secret = var.task_acr_sp_client_secret
+
+  subnet_id = module.resources.batch_nodepool_subnet
+}

--- a/deployment/terraform/dev/pools.tf
+++ b/deployment/terraform/dev/pools.tf
@@ -114,7 +114,7 @@ module "batch_pool_d3_v3_s2" {
   max_dedicated = 0
 
   min_low_priority = var.min_low_priority
-  max_low_priority = 2
+  max_low_priority = 100
 
   max_increase_per_scale = 50
 

--- a/deployment/terraform/resources/batch.tf
+++ b/deployment/terraform/resources/batch.tf
@@ -1,9 +1,10 @@
 resource "azurerm_storage_account" "pctasks-batch" {
-  name                     = substr("stb${local.nodash_prefix}", 0, 24)
-  resource_group_name      = azurerm_resource_group.pctasks.name
-  location                 = azurerm_resource_group.pctasks.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
+  name                            = substr("stb${local.nodash_prefix}", 0, 24)
+  resource_group_name             = azurerm_resource_group.pctasks.name
+  location                        = azurerm_resource_group.pctasks.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  allow_nested_items_to_be_public = false
 }
 
 resource "azurerm_batch_account" "pctasks" {

--- a/deployment/terraform/resources/storage_account.tf
+++ b/deployment/terraform/resources/storage_account.tf
@@ -1,9 +1,10 @@
 resource "azurerm_storage_account" "pctasks" {
-  name                     = local.nodash_prefix
-  resource_group_name      = azurerm_resource_group.pctasks.name
-  location                 = azurerm_resource_group.pctasks.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
+  name                            = local.nodash_prefix
+  resource_group_name             = azurerm_resource_group.pctasks.name
+  location                        = azurerm_resource_group.pctasks.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  allow_nested_items_to_be_public = false
 }
 
 # Tables

--- a/deployment/terraform/staging/pools.tf
+++ b/deployment/terraform/staging/pools.tf
@@ -99,3 +99,28 @@ module "batch_pool_d3_v3_landsat" {
 
   subnet_id = module.resources.batch_nodepool_subnet
 }
+
+module "batch_pool_d3_v3_s2" {
+  source = "../batch_pool"
+
+  name                = "s2_pool"
+  resource_group_name = module.resources.resource_group
+  account_name        = module.resources.batch_account_name
+  display_name        = "s2_pool"
+  vm_size             = "STANDARD_D3_V2"
+  max_tasks_per_node  = 4
+
+  min_dedicated = 0
+  max_dedicated = 0
+
+  min_low_priority = var.min_low_priority
+  max_low_priority = 2
+
+  max_increase_per_scale = 50
+
+  acr_name = var.task_acr_name
+  acr_client_id = var.task_acr_sp_client_id
+  acr_client_secret = var.task_acr_sp_client_secret
+
+  subnet_id = module.resources.batch_nodepool_subnet
+}

--- a/deployment/terraform/staging/pools.tf
+++ b/deployment/terraform/staging/pools.tf
@@ -114,7 +114,7 @@ module "batch_pool_d3_v3_s2" {
   max_dedicated = 0
 
   min_low_priority = var.min_low_priority
-  max_low_priority = 2
+  max_low_priority = 100
 
   max_increase_per_scale = 50
 


### PR DESCRIPTION
Sets the account-level flag for storage accounts to private, in addition to the container-level settings.