### PR TITLE
[noaa-mrms-qpe] Use pre-built Dockerfile

### DIFF
--- a/datasets/noaa-mrms-qpe/Dockerfile
+++ b/datasets/noaa-mrms-qpe/Dockerfile
@@ -1,0 +1,5 @@
+ARG registry
+FROM ${registry}/pctasks-task-base:latest
+
+COPY datasets/noaa-mrms-qpe /opt/src/datasets/noaa-mrms-qpe
+RUN python3 -m pip install -r /opt/src/datasets/noaa-mrms-qpe/requirements.txt

--- a/datasets/noaa-mrms-qpe/dataset.yaml
+++ b/datasets/noaa-mrms-qpe/dataset.yaml
@@ -1,5 +1,5 @@
 id: noaa_mrms_qpe
-image: ${{ args.registry }}/pctasks-task-base:latest
+image: ${{ args.registry }}/pctasks-noaa-mrms-qpe:latest
 
 args:
 - registry

--- a/datasets/noaa-mrms-qpe/workflows/update-noaa-mrms-qpe-1h-pass1.yaml
+++ b/datasets/noaa-mrms-qpe/workflows/update-noaa-mrms-qpe-1h-pass1.yaml
@@ -13,7 +13,7 @@ jobs:
     id: create-splits
     tasks:
     - id: create-splits
-      image: ${{ args.registry }}/pctasks-task-base:latest
+      image: ${{ args.registry }}/pctasks-noaa-mrms-qpe:latest
       code:
         src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
         requirements: datasets/noaa-mrms-qpe/requirements.txt
@@ -43,7 +43,7 @@ jobs:
     id: create-chunks
     tasks:
     - id: create-chunks
-      image: ${{ args.registry }}/pctasks-task-base:latest
+      image: ${{ args.registry }}/pctasks-noaa-mrms-qpe:latest
       code:
         src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
         requirements: datasets/noaa-mrms-qpe/requirements.txt
@@ -65,7 +65,7 @@ jobs:
     id: process-chunk
     tasks:
     - id: create-items
-      image: ${{ args.registry }}/pctasks-task-base:latest
+      image: ${{ args.registry }}/pctasks-noaa-mrms-qpe:latest
       code:
         src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
         requirements: datasets/noaa-mrms-qpe/requirements.txt

--- a/datasets/noaa-mrms-qpe/workflows/update-noaa-mrms-qpe-1h-pass2.yaml
+++ b/datasets/noaa-mrms-qpe/workflows/update-noaa-mrms-qpe-1h-pass2.yaml
@@ -13,7 +13,7 @@ jobs:
     id: create-splits
     tasks:
     - id: create-splits
-      image: ${{ args.registry }}/pctasks-task-base:latest
+      image: ${{ args.registry }}/pctasks-noaa-mrms-qpe:latest
       code:
         src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
         requirements: datasets/noaa-mrms-qpe/requirements.txt
@@ -43,7 +43,7 @@ jobs:
     id: create-chunks
     tasks:
     - id: create-chunks
-      image: ${{ args.registry }}/pctasks-task-base:latest
+      image: ${{ args.registry }}/pctasks-noaa-mrms-qpe:latest
       code:
         src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
         requirements: datasets/noaa-mrms-qpe/requirements.txt
@@ -65,7 +65,7 @@ jobs:
     id: process-chunk
     tasks:
     - id: create-items
-      image: ${{ args.registry }}/pctasks-task-base:latest
+      image: ${{ args.registry }}/pctasks-noaa-mrms-qpe:latest
       code:
         src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
         requirements: datasets/noaa-mrms-qpe/requirements.txt

--- a/datasets/noaa-mrms-qpe/workflows/update-noaa-mrms-qpe-24h-pass2.yaml
+++ b/datasets/noaa-mrms-qpe/workflows/update-noaa-mrms-qpe-24h-pass2.yaml
@@ -13,7 +13,7 @@ jobs:
     id: create-splits
     tasks:
     - id: create-splits
-      image: ${{ args.registry }}/pctasks-task-base:latest
+      image: ${{ args.registry }}/pctasks-noaa-mrms-qpe:latest
       code:
         src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
         requirements: datasets/noaa-mrms-qpe/requirements.txt
@@ -43,7 +43,7 @@ jobs:
     id: create-chunks
     tasks:
     - id: create-chunks
-      image: ${{ args.registry }}/pctasks-task-base:latest
+      image: ${{ args.registry }}/pctasks-noaa-mrms-qpe:latest
       code:
         src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
         requirements: datasets/noaa-mrms-qpe/requirements.txt
@@ -65,7 +65,7 @@ jobs:
     id: process-chunk
     tasks:
     - id: create-items
-      image: ${{ args.registry }}/pctasks-task-base:latest
+      image: ${{ args.registry }}/pctasks-noaa-mrms-qpe:latest
       code:
         src: datasets/noaa-mrms-qpe/noaa_mrms_qpe.py
         requirements: datasets/noaa-mrms-qpe/requirements.txt

--- a/deployment/terraform/dev/pools.tf
+++ b/deployment/terraform/dev/pools.tf
@@ -100,14 +100,14 @@ module "batch_pool_d3_v3_landsat" {
   subnet_id = module.resources.batch_nodepool_subnet
 }
 
-module "batch_pool_d3_v3_s2" {
+module "batch_pool_s2" {
   source = "../batch_pool"
 
   name                = "s2_pool"
   resource_group_name = module.resources.resource_group
   account_name        = module.resources.batch_account_name
   display_name        = "s2_pool"
-  vm_size             = "STANDARD_D3_V2"
+  vm_size             = "STANDARD_D4_V4"
   max_tasks_per_node  = 4
 
   min_dedicated = 0

--- a/deployment/terraform/staging/pools.tf
+++ b/deployment/terraform/staging/pools.tf
@@ -100,14 +100,14 @@ module "batch_pool_d3_v3_landsat" {
   subnet_id = module.resources.batch_nodepool_subnet
 }
 
-module "batch_pool_d3_v3_s2" {
+module "batch_pool_s2" {
   source = "../batch_pool"
 
   name                = "s2_pool"
   resource_group_name = module.resources.resource_group
   account_name        = module.resources.batch_account_name
   display_name        = "s2_pool"
-  vm_size             = "STANDARD_D3_V2"
+  vm_size             = "STANDARD_D4_V4"
   max_tasks_per_node  = 4
 
   min_dedicated = 0


### PR DESCRIPTION
Our nightly job had some failures, ending with

```
  File "/opt/conda/lib/python3.8/site-packages/pip/_vendor/urllib3/response.py", line 454, in _error_catcher
    raise ProtocolError("Connection broken: %r" % e, e)
pip._vendor.urllib3.exceptions.ProtocolError: ("Connection broken: ConnectionResetError(104, 'Connection reset by peer')", ConnectionResetError(104, 'Connection reset by peer'))
```

i.e. our runtime pip install failed. Moving this to a pre-built container with all the dependencies.