### PR TITLE
[core]: Prioritize uploaded code on sys.path

### DIFF
--- a/Dockerfile.task_base
+++ b/Dockerfile.task_base
@@ -29,7 +29,7 @@ RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/downloa
 ENV PATH /opt/conda/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/conda/lib/:$LD_LIBRARY_PATH
 
-RUN mamba install -y -c conda-forge python=3.8 gdal=3.3.3 pip setuptools cython numpy==1.21.5
+RUN mamba install -y -c conda-forge python=3.8 gdal pip setuptools cython numpy
 
 RUN python -m pip install --upgrade pip
 

--- a/docs/user_guide/runtime.md
+++ b/docs/user_guide/runtime.md
@@ -55,4 +55,5 @@ Your code is importable with `import mypackage`, `from mypackage import module_a
 Behind the scenes, when you submit a workflow generated from this `dataset.yaml`
 the module is uploaded to Azure Blob Storage. Before executing your task, the
 worker downloads that module and places it in a location that's importable by
-the Python interpreter.
+the Python interpreter. The uploaded module / package is prioritized over any
+existing modules with the same import name.

--- a/pctasks/core/pctasks/core/importer.py
+++ b/pctasks/core/pctasks/core/importer.py
@@ -130,6 +130,6 @@ def ensure_code(
         is_package = zipfile.is_zipfile(output_path)
     if is_package:
         logger.debug("Adding %s to sys.path", output_path)
-        sys.path.append(str(output_path))
+        sys.path.insert(0, str(output_path))
 
     return pathlib.Path(output_path)

--- a/pctasks/core/tests/storage/test_importer.py
+++ b/pctasks/core/tests/storage/test_importer.py
@@ -64,6 +64,7 @@ def _import_package(target_dir: Optional[str] = None):
         assert instance.a() == "a"
         assert instance.b() == "b"
         assert result.name == "example_module.zip"
+        assert Path(sys.path[0]).name == "example_module.zip"
 
 
 def test_import_package():


### PR DESCRIPTION
This change moves uploaded code to the front of sys.path, effectively overwriting any existing code with newly uploaded code. IMO, this is the more expected behavior.