### PR TITLE
Add with_backoff to all CosmosDB operations

### DIFF
--- a/pctasks/core/pctasks/core/cosmos/container.py
+++ b/pctasks/core/pctasks/core/cosmos/container.py
@@ -5,6 +5,7 @@ from itertools import groupby
 from typing import (
     Any,
     AsyncIterable,
+    AsyncIterator,
     Callable,
     Dict,
     Generic,
@@ -36,6 +37,7 @@ from pctasks.core.cosmos.settings import CosmosDBSettings
 from pctasks.core.models.run import Record
 from pctasks.core.models.utils import tzutc_now
 from pctasks.core.utils import grouped
+from pctasks.core.utils.backoff import BackoffStrategy, with_backoff, with_backoff_async
 
 T = TypeVar("T", bound=Record)
 
@@ -70,6 +72,7 @@ class BaseCosmosDBContainer(Generic[T], ABC):
             Dict[ContainerOperation, Dict[Type[BaseModel], str]]
         ] = None,
         triggers: Optional[Dict[ContainerOperation, Dict[TriggerType, str]]] = None,
+        with_backoff_waits: Optional[List[float]] = None,
     ) -> None:
         if not settings:
             if db:
@@ -87,6 +90,21 @@ class BaseCosmosDBContainer(Generic[T], ABC):
         self.name = name
         self.stored_procedures = stored_procedures
         self.triggers = triggers
+
+        self.backoff_strategy = BackoffStrategy(
+            waits=with_backoff_waits
+            or [
+                0.1,
+                0.2,
+                0.3,
+                0.4,
+                0.5,
+                1,
+                2,
+                5,
+                10,
+            ]
+        )
 
     @abstractmethod
     def get_partition_key(self, model: T) -> str:
@@ -220,8 +238,11 @@ class CosmosDBContainer(BaseCosmosDBContainer[T], ABC):
 
         if stored_proc:
             partition_key = self.get_partition_key(model)
-            self._container_client.scripts.execute_stored_procedure(
-                stored_proc, partition_key=partition_key, params=[item]
+            with_backoff(
+                lambda: self._container_client.scripts.execute_stored_procedure(
+                    stored_proc, partition_key=partition_key, parameters=[item]
+                ),
+                strategy=self.backoff_strategy,
             )
         else:
             # Otherwise upsert the item
@@ -246,18 +267,26 @@ class CosmosDBContainer(BaseCosmosDBContainer[T], ABC):
                 f"and model {type(models[0])}. Falling back to individual puts."
             )
             for model in models:
-                self.put(model)
+                with_backoff(lambda: self.put(model))
         else:
             for partition_key, item_group in self._group_for_bulk_put(models):
-                self._container_client.scripts.execute_stored_procedure(
-                    stored_proc,
-                    partition_key=partition_key,
-                    params=[list(item_group)],
+                with_backoff(
+                    lambda: self._container_client.scripts.execute_stored_procedure(
+                        stored_proc,
+                        partition_key=partition_key,
+                        params=[list(item_group)],
+                    ),
+                    strategy=self.backoff_strategy,
                 )
 
     def get(self, id: str, partition_key: str) -> Optional[T]:
         try:
-            item = self._container_client.read_item(id, partition_key=partition_key)
+            item = with_backoff(
+                lambda: self._container_client.read_item(
+                    id, partition_key=partition_key
+                ),
+                strategy=self.backoff_strategy,
+            )
         except CosmosResourceNotFoundError:
             return None
         if item.get("deleted"):
@@ -277,18 +306,28 @@ class CosmosDBContainer(BaseCosmosDBContainer[T], ABC):
 
         item_paged = cast(
             ItemPaged[Dict[str, Any]],
-            self._container_client.query_items(
-                query=query,
-                parameters=params,
-                partition_key=partition_key,
-                max_item_count=page_size,
+            with_backoff(
+                lambda: self._container_client.query_items(
+                    query=query,
+                    parameters=params,
+                    partition_key=partition_key,
+                    max_item_count=page_size,
+                ),
+                strategy=self.backoff_strategy,
             ),
         )
         paged_iterator = cast(
             PageIterator[Dict[str, Any]],
-            item_paged.by_page(continuation_token=continuation_token),
+            with_backoff(
+                lambda: item_paged.by_page(continuation_token=continuation_token)
+            ),
         )
-        for page in paged_iterator:
+        # Grab the iterator and loop with a while yielding results
+        while True:
+            page = with_backoff(
+                lambda: next(paged_iterator),
+                strategy=self.backoff_strategy,
+            )
             continuation_token = paged_iterator.continuation_token
             yield Page(
                 items=map(
@@ -368,19 +407,32 @@ class AsyncCosmosDBContainer(BaseCosmosDBContainer[T], ABC):
 
         if stored_proc:
             partition_key = self.get_partition_key(model)
-            await self._container_client.scripts.execute_stored_procedure(
-                stored_proc, partition_key=partition_key, params=[item]
+
+            async def _sp() -> Dict[str, Any]:
+                return await self._container_client.scripts.execute_stored_procedure(
+                    stored_proc, partition_key=partition_key, parameters=[item]
+                )
+
+            await with_backoff_async(
+                _sp,
+                strategy=self.backoff_strategy,
             )
         else:
             # Otherwise upsert the item
-            await self._container_client.upsert_item(
-                item,
-                pre_trigger_include=self.get_trigger(
-                    ContainerOperation.PUT, TriggerType.PRE
-                ),
-                post_trigger_include=self.get_trigger(
-                    ContainerOperation.PUT, TriggerType.POST
-                ),
+            async def _upsert() -> Dict[str, Any]:
+                return await self._container_client.upsert_item(
+                    item,
+                    pre_trigger_include=self.get_trigger(
+                        ContainerOperation.PUT, TriggerType.PRE
+                    ),
+                    post_trigger_include=self.get_trigger(
+                        ContainerOperation.PUT, TriggerType.POST
+                    ),
+                )
+
+            await with_backoff_async(
+                _upsert,
+                strategy=self.backoff_strategy,
             )
 
     async def bulk_put(self, models: Iterable[T]) -> None:
@@ -396,17 +448,34 @@ class AsyncCosmosDBContainer(BaseCosmosDBContainer[T], ABC):
             for model in models:
                 await self.put(model)
         else:
+
             for partition_key, item_group in self._group_for_bulk_put(models):
-                await self._container_client.scripts.execute_stored_procedure(
-                    stored_proc,
-                    partition_key=partition_key,
-                    params=[list(item_group)],
+
+                async def _sp() -> Dict[str, Any]:
+                    return (
+                        await self._container_client.scripts.execute_stored_procedure(
+                            stored_proc,
+                            partition_key=partition_key,
+                            params=[list(item_group)],
+                        )
+                    )
+
+                await with_backoff_async(
+                    _sp,
+                    strategy=self.backoff_strategy,
                 )
 
     async def get(self, id: str, partition_key: str) -> Optional[T]:
         try:
-            item = await self._container_client.read_item(
-                id, partition_key=partition_key
+
+            async def _read() -> Dict[str, Any]:
+                return await self._container_client.read_item(
+                    id, partition_key=partition_key
+                )
+
+            item = await with_backoff_async(
+                _read,
+                strategy=self.backoff_strategy,
             )
         except CosmosResourceNotFoundError:
             return None
@@ -438,7 +507,17 @@ class AsyncCosmosDBContainer(BaseCosmosDBContainer[T], ABC):
             AsyncPageIterator[Dict[str, Any]],
             item_paged.by_page(continuation_token=continuation_token),
         )
-        async for page in paged_iterator:
+
+        async def _next_page() -> Optional[AsyncIterator[Dict[str, Any]]]:
+            try:
+                return await paged_iterator.__anext__()
+            except StopAsyncIteration:
+                return None
+
+        while True:
+            page = await with_backoff_async(_next_page, strategy=self.backoff_strategy)
+            if not page:
+                break
             continuation_token = paged_iterator.continuation_token
             yield Page(
                 items=[

--- a/pctasks/core/pctasks/core/utils/backoff.py
+++ b/pctasks/core/pctasks/core/utils/backoff.py
@@ -1,8 +1,9 @@
+import asyncio
 import logging
 import random
 import time
 from dataclasses import dataclass, field
-from typing import Callable, List, Optional, TypeVar
+from typing import Any, Callable, Coroutine, List, Optional, TypeVar
 
 T = TypeVar("T")
 
@@ -12,6 +13,15 @@ logger = logging.getLogger(__name__)
 
 class BackoffError(Exception):
     pass
+
+    @classmethod
+    def after(cls, strategy: "BackoffStrategy") -> "BackoffError":
+        # Try as we might, sometimes we fail
+        return cls(
+            "Potential throttling issue - see inner exception. "
+            f"Tried backoff {len(strategy.waits)} times "
+            f"up to {strategy.waits[-1]} seconds"
+        )
 
 
 def get_exception_status_code(e: Exception) -> Optional[int]:
@@ -90,6 +100,17 @@ class BackoffStrategy:
         sp = self.spread_precentage
         return seconds * random.uniform(1 - sp, 1 + sp)
 
+    def get_waits(self) -> List[float]:
+        """Returns a copy of the waits list"""
+        return [self.spread(w) for w in self.waits]
+
+
+def _warn_throttle(wait_time: float, throttle_exception: Exception) -> None:
+    logger.warning(
+        f"Service responded with {throttle_exception} - "
+        f"trying again in {wait_time:.1f} seeconds..."
+    )
+
 
 def with_backoff(
     fn: Callable[[], T],
@@ -108,7 +129,7 @@ def with_backoff(
 
     throttle_exception: Optional[Exception] = None
 
-    for backoff_wait_seconds in strategy.waits:
+    for next_wait in strategy.get_waits():
         try:
 
             # Try to do the thing and return
@@ -117,19 +138,45 @@ def with_backoff(
         except Exception as e:
             if is_throttle(e):
                 # Handle throttling by backing off a random bit
-                actual_wait = backoff_wait_seconds * random.uniform(0.8, 1.2)
-                logger.warning(
-                    f"Service responded with throttling message - "
-                    f"trying again in {actual_wait:.1f} seconds..."
-                )
-                time.sleep(actual_wait)
+                _warn_throttle(next_wait, e)
+                time.sleep(next_wait)
                 throttle_exception = e
             else:
                 raise
 
-    # Try as we might, sometimes we fail
-    raise BackoffError(
-        "Potential throttling issue - see inner exception. "
-        f"Tried backoff {len(strategy.waits)} times "
-        f"up to {strategy.waits[-1]} seconds"
-    ) from throttle_exception
+    raise BackoffError.after(strategy) from throttle_exception
+
+
+async def with_backoff_async(
+    fn: Callable[[], Coroutine[Any, Any, T]],
+    strategy: Optional[BackoffStrategy] = None,
+    is_throttle: Optional[Callable[[Exception], bool]] = None,
+) -> T:
+    """Executes the given function fn. If an exception is raised
+    that returns True from is_throttle, wait for a bit and try again,
+    or fail after so many retries.
+    """
+    if strategy is None:
+        strategy = BackoffStrategy()
+
+    if is_throttle is None:
+        is_throttle = is_common_throttle_exception
+
+    throttle_exception: Optional[Exception] = None
+
+    for next_wait in strategy.get_waits():
+        try:
+
+            # Try to do the thing and return
+            return await fn()
+
+        except Exception as e:
+            if is_throttle(e):
+                # Backoff for the wait time
+                _warn_throttle(next_wait, e)
+                await asyncio.sleep(next_wait)
+                throttle_exception = e
+            else:
+                raise
+
+    raise BackoffError.after(strategy) from throttle_exception

--- a/pctasks/core/tests/cosmos/test_container.py
+++ b/pctasks/core/tests/cosmos/test_container.py
@@ -1,7 +1,8 @@
 from typing import Any, Dict, List, Tuple, Type
 
-from pctasks.core.cosmos.container import CosmosDBContainer
+from pctasks.core.cosmos.container import AsyncCosmosDBContainer, CosmosDBContainer
 from pctasks.core.cosmos.database import CosmosDBDatabase
+from pctasks.core.cosmos.page import Page
 from pctasks.core.models.record import Record
 from pctasks.dev.cosmosdb import temp_cosmosdb_if_emulator
 
@@ -9,6 +10,7 @@ from pctasks.dev.cosmosdb import temp_cosmosdb_if_emulator
 class MockModel(Record):
     type: str = "MOCK"
     id: str
+    group_id: str = "None"
     name: str
 
     def get_id(self) -> str:
@@ -40,6 +42,19 @@ class MockContainer(CosmosDBContainer[MockModel]):
         return item
 
 
+class AsyncMockContainer(AsyncCosmosDBContainer[MockModel]):
+    container_name: str = "mock"
+    partition_key: str = "/group_id"
+
+    def __init__(self, db: CosmosDBDatabase) -> None:
+        self._items_to_models: List[Tuple[Dict[str, Any], MockModel]] = []
+        self._models_to_items: List[Tuple[MockModel, Dict[str, Any]]] = []
+        super().__init__(self.container_name, self.partition_key, MockModel, db=db)
+
+    def get_partition_key(self, model: MockModel) -> str:
+        return model.id
+
+
 def test_container_transforms_models():
     with temp_cosmosdb_if_emulator(
         containers={MockContainer.container_name: MockContainer.partition_key}
@@ -58,3 +73,38 @@ def test_container_transforms_models():
             for model, item in container._models_to_items:
                 assert item["mock_id"] == item["id"]
                 assert item["id"] == model.id
+
+
+async def test_container_async():
+    with temp_cosmosdb_if_emulator(
+        containers={AsyncMockContainer.container_name: AsyncMockContainer.partition_key}
+    ) as db:
+        original = MockModel(id="1", name="one", group_id="A")
+        container = AsyncMockContainer(db=db)
+        async with container:
+            await container.put(original)
+            result = await container.get(id="1", partition_key="A")
+
+            assert result == original
+            for item, model in container._items_to_models:
+                assert item["mock_id"] == item["id"]
+                assert item["id"] == model.id
+
+            for model, item in container._models_to_items:
+                assert item["mock_id"] == item["id"]
+                assert item["id"] == model.id
+
+            others = [
+                MockModel(id=str(i), name=str(i), group_id="A") for i in range(2, 10)
+            ]
+            await container.bulk_put(others)
+
+            pages: List[Page[MockModel]] = []
+            async for page in container.query_paged(
+                query="SELECT * FROM c where c.group_id = 'A' ",
+                partition_key="A",
+                page_size=2,
+            ):
+                pages.append(page)
+
+            assert len(pages) == 5

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@ black==22.*
 mypy==0.982
 pytest==6.*
 isort==5.*
+pytest-asyncio==0.18.*
 
 planetary-computer
 pystac[validation]==1.*


### PR DESCRIPTION
## Description

Currently we don't have retry logic in the case where CosmosDB throws a 429. 

This pull request adds a with_backoff function to all CosmosDB operations to implement retry logic in the event that a 429 error is thrown by CosmosDB. This will ensure that our application can handle and recover from temporary spikes in request volume to CosmosDB, improving its overall reliability and resilience. (<- output from ChatGPT :-))

This change required porting in some of the with_backoff functionality in [planetary-computer-apis](https://github.com/microsoft/planetary-computer-apis/blob/main/pccommon/pccommon/backoff.py), including an async version. It also adds some test to the core container tests for async puts and gets.

This was not tested against actual throttle messages; however the exceptions that are thrown have a "status_code" property that has the value of 429, so should be picked up by with_backoff - we will monitor this in a test deployment where we've seen throttling exceptions as a final test.