### PR TITLE
Add timeout option for BlobStorage.download_file

### DIFF
--- a/pctasks/core/pctasks/core/storage/blob.py
+++ b/pctasks/core/pctasks/core/storage/blob.py
@@ -509,8 +509,11 @@ class BlobStorage(Storage):
             with client.container.get_blob_client(self._add_prefix(file_path)) as blob:
                 with open(output_path, "wb" if is_binary else "w") as f:
                     try:
+                        # timeout raises an azure.core.exceptions.HttpResponseError: ("Connection broken: ConnectionResetError(104, 'Connection reset by peer')"  # noqa
                         with_backoff(
-                            lambda: blob.download_blob(timeout=timeout_seconds).readinto(f)
+                            lambda: blob.download_blob(
+                                timeout=timeout_seconds
+                            ).readinto(f)
                         )
                     except azure.core.exceptions.ResourceNotFoundError:
                         raise FileNotFoundError(f"File {file_path} not found in {self}")

--- a/pctasks/core/pctasks/core/storage/blob.py
+++ b/pctasks/core/pctasks/core/storage/blob.py
@@ -503,12 +503,15 @@ class BlobStorage(Storage):
         file_path: str,
         output_path: str,
         is_binary: bool = True,
+        timeout_seconds: Optional[int] = None,
     ) -> None:
         with self._get_client() as client:
             with client.container.get_blob_client(self._add_prefix(file_path)) as blob:
                 with open(output_path, "wb" if is_binary else "w") as f:
                     try:
-                        with_backoff(lambda: blob.download_blob().readinto(f))
+                        with_backoff(
+                            lambda: blob.download_blob(timeout=timeout_seconds).readinto(f)
+                        )
                     except azure.core.exceptions.ResourceNotFoundError:
                         raise FileNotFoundError(f"File {file_path} not found in {self}")
 

--- a/pctasks/core/tests/storage/test_blob.py
+++ b/pctasks/core/tests/storage/test_blob.py
@@ -78,3 +78,25 @@ def test_fsspec_components():
             storage.fsspec_path("foo/bar.csv")
             == f"abfs://{TEST_DATA_CONTAINER}/foo/bar.csv"
         )
+
+
+def test_blob_download_timeout():
+    TIMEOUT_SECONDS = 5
+    with temp_azurite_blob_storage(
+        HERE / ".." / "data-files" / "simple-assets"
+    ) as storage:
+        with storage._get_client() as client:
+            with client.container.get_blob_client(
+                storage._add_prefix("a/asset-a-1.json")
+            ) as blob:
+                storage_stream_downloader = blob.download_blob(timeout=TIMEOUT_SECONDS)
+                assert (
+                    storage_stream_downloader._request_options["timeout"]
+                    == TIMEOUT_SECONDS
+                )
+
+                storage_stream_downloader = blob.download_blob()
+                assert (
+                    storage_stream_downloader._request_options.pop("timeout", None)
+                    is None
+                )


### PR DESCRIPTION
## Description

pctasks `BlobStorage.download_file` can hang indefinitely. This PR adds a `timeout_seconds` option to the `download_file` method that gets passed through to the Azure SDK to force an error for hanging downloads.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- I was not able to create a test that failed (download takes longer than minimum timeout, which is in integer seconds) via the azurite tools available in `pctasks.dev.blob`
- I empirically tested the timeout on Azure blobs of a few tens of MB, and it performs as desired: you can cause a `download_file` call to fail with a very short `timeout_seconds` of 1 or 2 seconds. Increase to 10 seconds and the download succeeds.
- I added a test to pctasks > core > tests > storage > test_blob.py that partially recreates the `download_file` method and checks that the `timeout_seconds` value is correctly parsed and passed along to the Azure SDK functions.

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test) 
- [x] Code is linted and styled (./scripts/format)