### PR TITLE
NOAA Climate Normals: Add missing custom field prefix

### DIFF
--- a/datasets/noaa-climate-normals/collection/noaa-climate-normals-gridded/template.json
+++ b/datasets/noaa-climate-normals/collection/noaa-climate-normals-gridded/template.json
@@ -424,13 +424,13 @@
         }
     },
     "summaries": {
-        "frequency": [
+        "noaa_climate_normals:frequency": [
             "daily",
             "monthly",
             "seasonal",
             "annual"
         ],
-        "period": [
+        "noaa_climate_normals:period": [
             "1901-2000",
             "1991-2020",
             "2006-2020"

--- a/datasets/noaa-climate-normals/collection/noaa-climate-normals-netcdf/template.json
+++ b/datasets/noaa-climate-normals/collection/noaa-climate-normals-netcdf/template.json
@@ -118,11 +118,11 @@
         }
     },
     "summaries": {
-        "frequency": [
+        "noaa_climate_normals:frequency": [
             "daily",
             "monthly"
         ],
-        "period": [
+        "noaa_climate_normals:period": [
             "1901-2000",
             "1991-2020",
             "2006-2020"

--- a/datasets/noaa-climate-normals/collection/noaa-climate-normals-tabular/template.json
+++ b/datasets/noaa-climate-normals/collection/noaa-climate-normals-tabular/template.json
@@ -121,13 +121,13 @@
         }
     },
     "summaries": {
-        "frequency": [
+        "noaa_climate_normals:frequency": [
             "hourly",
             "daily",
             "monthly",
             "annualseasonal"
         ],
-        "period": [
+        "noaa_climate_normals:period": [
             "1981-2010",
             "1991-2020",
             "2006-2020"

--- a/datasets/noaa-climate-normals/dataset.yaml
+++ b/datasets/noaa-climate-normals/dataset.yaml
@@ -32,10 +32,10 @@ collections:
           options:
             name_starts_with: access
             extensions: [.csv]
-            chunk_length: 1
-            limit: 1
+            chunk_length: 1 # this is correct for production; we only want one csv href
+            limit: 1 # this is correct for production; we only want one csv href
           splits:
-            - depth: 2
+            - depth: 2  # this drops us into each subdirectory of interest
     chunk_storage:
       uri: blob://noaanormals/normals-etl-data/tabular/
 
@@ -58,9 +58,9 @@ collections:
         chunks:
           options:
             extensions: [.nc]
-            chunk_length: 1
-            limit: 1
+            chunk_length: 1  # this is correct for production; we only want one nc href
+            limit: 1  # this is correct for production; we only want one nc href
           splits:
-            - depth: 2
+            - depth: 2  # this drops us into each subdirectory of interest
     chunk_storage:
       uri: blob://noaanormals/normals-etl-data/gridded/

--- a/datasets/noaa-climate-normals/requirements.txt
+++ b/datasets/noaa-climate-normals/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/stactools-packages/noaa-climate-normals.git@f2557e5a591308054989c6969ef8615b7d57084a
+git+https://github.com/stactools-packages/noaa-climate-normals.git@2d574925ac928d4705f3f9e85f5fbb4794d0593f


### PR DESCRIPTION
## Description

The extra property fields (e.g., `noaa_climate_normals:period`, `noaa-climate-normals:frequency`) were missing the prefix `noaa_climate_normals` in the Collection templates and Item creation. This was fixed in the stactools package and the corrections propagated into pctasks via this PR. 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- New Items for the `netcdf` and `gridded` Collections were created and ingested into PC Test to validate the correction.
- Due to the extended Item creation time for `tabular` data, new tabular Items were not created and ingested into PC Test. The corrections to the tabular Items can be seen in the stactools package [examples](https://github.com/stactools-packages/noaa-climate-normals/tree/main/examples/noaa-climate-normals-tabular) and will be realized when Items are created and ingested into Staging.

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)