### PR TITLE
Correct pass and period in noaa-mrms-qpe-24h-pass2 collection summaries

### DIFF
--- a/datasets/noaa-mrms-qpe/collection/noaa-mrms-qpe-24h-pass2/template.json
+++ b/datasets/noaa-mrms-qpe/collection/noaa-mrms-qpe-24h-pass2/template.json
@@ -170,10 +170,10 @@
     },
     "summaries": {
         "noaa_mrms_qpe:pass": [
-            1
+            2
         ],
         "noaa_mrms_qpe:period": [
-            1
+            24
         ],
         "noaa_mrms_qpe:region": [
             "CONUS",


### PR DESCRIPTION
## Description

Corrects pass (was 1, now 2) and period (was 1, now 24) in the summaries section of the noaa-mrms-qpe-24h-pass2 collection template.

Fixes https://github.com/microsoft/PlanetaryComputerDataCatalog/issues/390

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Not tested. 

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)