### PR TITLE
Use federated identity for GHA/Azure

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,6 +21,13 @@ jobs:
         with:
           python-version: "3.8"
 
+      - name: 'Az CLI login'
+        uses: azure/login@v1
+        with:
+            client-id: ${{ secrets.AZURE_CLIENT_ID }}
+            tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+            subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
       - name: Install local dependencies
         run: ./scripts/install
 

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,6 +10,9 @@ env:
   PCTASKS_COSMOSDB__KEY: ${{ secrets.COSMOSDB_KEY }}
   PCTASKS_COSMOSDB__TEST_CONTAINER_SUFFIX: ${{ github.run_id }}
 
+permissions:
+  id-token: write
+
 jobs:
   build_and_publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -79,7 +79,7 @@ jobs:
         run: ./scripts/publish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}} --no-login
 
       - name: Log into the ACR
-        run: az acr login -n pccomponentstest
+        run: az acr login -n pccomponents
 
       - name: Publish images
         run: ./scripts/publish --acr pccomponents --tag ${{steps.get_image_tag.outputs.tag}} --no-login

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -70,19 +70,13 @@ jobs:
           esac
 
       - name: Log into the ACR (test)
-        env:
-          CLIENT_ID: ${{ fromJSON(secrets.AZURE_CREDENTIALS).clientId }}
-          CLIENT_SECRET: ${{ fromJSON(secrets.AZURE_CREDENTIALS).clientSecret }}
-        run: docker login pccomponentstest.azurecr.io --username ${CLIENT_ID} --password ${CLIENT_SECRET}
+        run: az acr login -n pccomponentstest
 
       - name: Publish images (test)
         run: ./scripts/publish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}} --no-login
 
       - name: Log into the ACR
-        env:
-          CLIENT_ID: ${{ fromJSON(secrets.AZURE_CREDENTIALS).clientId }}
-          CLIENT_SECRET: ${{ fromJSON(secrets.AZURE_CREDENTIALS).clientSecret }}
-        run: docker login pccomponents.azurecr.io --username ${CLIENT_ID} --password ${CLIENT_SECRET}
+        run: az acr login -n pccomponentstest
 
       - name: Publish images
         run: ./scripts/publish --acr pccomponents --tag ${{steps.get_image_tag.outputs.tag}} --no-login


### PR DESCRIPTION
CI was failing on main because of an expired secret. This connects GitHub Actions to Azure using the guide at
https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Clinux.

I set up the federated identity for our Service Principal. I added those secrets (AZURE_CLIENT_ID, AZURE_TENANT_ID, AZURE_SUBSCRIPTION_ID) to our GitHub Actions repository secrets.