### PR TITLE
Bump stactools-usda-cdl to v0.1.2

### DIFF
--- a/datasets/usda-cdl/requirements.txt
+++ b/datasets/usda-cdl/requirements.txt
@@ -1,1 +1,1 @@
-stactools-usda-cdl == 0.1.1
+stactools-usda-cdl == 0.1.2


### PR DESCRIPTION
## Description

Update `stactools-usda-cdl` dependency to pick up https://github.com/stactools-packages/usda-cdl/commit/78c9e8ffb01685d465315c6fb5af49667ac59a59.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I've re-tiled the data and the staging explorer looks better? I can't quite be sure b/c there's still some edge effects at far-out zoom but that should just be caching issues, many mid-level zooms look good.

## Checklist:

- [x] I have performed a self-review
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)