### PR TITLE
Fix fws-nwi data locations

### DIFF
--- a/datasets/fws-nwi/dataset.yaml
+++ b/datasets/fws-nwi/dataset.yaml
@@ -14,10 +14,10 @@ collections:
     template: ${{ local.path(./collection) }}
     class: fws_nwi:FwsNwiCollection
     asset_storage:
-      - uri: blob://ai4edataeuwest/fws-nwi/
+      - uri: blob://landcoverdata/fws-nwi-onboarding/
         chunks:
           options:
             extensions: [.zip]
             chunk_length: 1
     chunk_storage:
-      uri: blob://ai4edataeuwest/fws-nwi-etl-data/
+      uri: blob://landcoverdata/fws-nwi-etl-data/

--- a/datasets/fws-nwi/fws_nwi.py
+++ b/datasets/fws-nwi/fws_nwi.py
@@ -9,7 +9,7 @@ from stactools.fws_nwi.constants import ZIPFILE_ASSET_KEY
 from pctasks.core.storage import StorageFactory
 from pctasks.dataset.collection import Collection
 
-GEOPARQUET_CONTAINER = "blob://ai4edataeuwest/fws-nwi/geoparquet"
+GEOPARQUET_CONTAINER = "blob://landcoverdata/fws-nwi/geoparquet"
 
 
 class FwsNwiCollection(Collection):


### PR DESCRIPTION
## Description

pc-onboarding for FWS-NWI put things in the `landcoverdata` storage account, so this PR updates the rest of the asset locations to match.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I ran the geoparquet creation into the new locations.

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)