### PR TITLE
Add service principal secrets to item ingest task

### DIFF
--- a/pctasks/ingest/pctasks/ingest/_cli.py
+++ b/pctasks/ingest/pctasks/ingest/_cli.py
@@ -30,6 +30,7 @@ def ingest_ndjson_cmd(
     submit: bool,
     limit: Optional[int],
     workflow_id: Optional[str] = None,
+    add_service_principal: bool = True,
 ) -> None:
     """Ingest Items from a folder of Ndjsons.
 
@@ -64,6 +65,7 @@ def ingest_ndjson_cmd(
         ),
         target=target,
         option=ingest_config,
+        add_service_principal=add_service_principal,
     )
 
     job = JobDefinition(tasks=[task])

--- a/pctasks/ingest/pctasks/ingest/cli.py
+++ b/pctasks/ingest/pctasks/ingest/cli.py
@@ -43,6 +43,9 @@ from pctasks.ingest.constants import DEFAULT_INSERT_GROUP_SIZE
 @click.option("--limit", type=int, help="Limit the number of ndjson files to ingest.")
 @click.option("-s", "--submit", is_flag=True, help="Submit the workflow.")
 @click.option("--workflow-id", help="Workflow ID")
+@click.option(
+    "--no-add-service-principal", is_flag=True, help="Do not add service principal"
+)
 @click.pass_context
 def ingest_ndjson_cmd(
     ctx: click.Context,
@@ -61,6 +64,7 @@ def ingest_ndjson_cmd(
     submit: bool,
     limit: Optional[int],
     workflow_id: Optional[str] = None,
+    no_add_service_principal: bool = False,
 ) -> None:
     """Ingest Items from a folder of Ndjsons.
 
@@ -89,6 +93,7 @@ def ingest_ndjson_cmd(
         submit,
         limit,
         workflow_id=workflow_id,
+        add_service_principal=not no_add_service_principal,
     )
 
 

--- a/pctasks/ingest/pctasks/ingest/models.py
+++ b/pctasks/ingest/pctasks/ingest/models.py
@@ -99,6 +99,7 @@ class IngestTaskConfig(TaskDefinition):
         environment: Optional[Dict[str, str]] = None,
         options: Optional[IngestOptions] = None,
         ingest_settings: Optional[IngestSettings] = None,
+        add_service_principal: bool = True,
     ) -> TaskDefinition:
         data = IngestTaskInput(
             content=content,
@@ -116,6 +117,14 @@ class IngestTaskConfig(TaskDefinition):
             raise ValueError(
                 "Must supply image_key or "
                 f"environment[{DB_CONNECTION_STRING_ENV_VAR}]"
+            )
+
+        environment = environment or {}
+        if add_service_principal:
+            environment.setdefault("AZURE_TENANT_ID", "${{ secrets.task-tenant-id }}")
+            environment.setdefault("AZURE_CLIENT_ID", "${{ secrets.task-client-id }}")
+            environment.setdefault(
+                "AZURE_CLIENT_SECRET", "${{ secrets.task-client-secret }}"
             )
 
         return TaskDefinition(
@@ -137,6 +146,7 @@ class IngestTaskConfig(TaskDefinition):
         environment: Optional[Dict[str, str]] = None,
         options: Optional[IngestOptions] = None,
         ingest_settings: Optional[IngestSettings] = None,
+        add_service_principal: bool = True,
     ) -> TaskDefinition:
         if "collection" not in item:
             raise InvalidSTACException("Item is missing a collection.")
@@ -149,6 +159,7 @@ class IngestTaskConfig(TaskDefinition):
             environment=environment,
             options=options,
             ingest_settings=ingest_settings,
+            add_service_principal=add_service_principal,
         )
 
     @classmethod
@@ -160,6 +171,7 @@ class IngestTaskConfig(TaskDefinition):
         environment: Optional[Dict[str, str]] = None,
         options: Optional[IngestOptions] = None,
         ingest_settings: Optional[IngestSettings] = None,
+        add_service_principal: bool = True,
     ) -> TaskDefinition:
         if "id" not in collection:
             raise InvalidSTACException("Collection is missing an id.")
@@ -172,6 +184,7 @@ class IngestTaskConfig(TaskDefinition):
             environment=environment,
             options=options,
             ingest_settings=ingest_settings,
+            add_service_principal=add_service_principal,
         )
 
     @classmethod
@@ -183,6 +196,7 @@ class IngestTaskConfig(TaskDefinition):
         environment: Optional[Dict[str, str]] = None,
         options: Optional[IngestOptions] = None,
         ingest_settings: Optional[IngestSettings] = None,
+        add_service_principal: bool = True,
     ) -> TaskDefinition:
 
         return cls.create(
@@ -193,6 +207,7 @@ class IngestTaskConfig(TaskDefinition):
             environment=environment,
             options=options,
             ingest_settings=ingest_settings,
+            add_service_principal=add_service_principal,
         )
 
     @classmethod
@@ -204,6 +219,7 @@ class IngestTaskConfig(TaskDefinition):
         environment: Optional[Dict[str, str]] = None,
         option: Optional[IngestOptions] = None,
         ingest_settings: Optional[IngestSettings] = None,
+        add_service_principal: bool = True,
     ) -> TaskDefinition:
         return cls.create(
             task_id=NDJSON_TASK_ID,
@@ -213,4 +229,5 @@ class IngestTaskConfig(TaskDefinition):
             environment=environment,
             options=option,
             ingest_settings=ingest_settings,
+            add_service_principal=add_service_principal,
         )

--- a/pctasks/ingest/pctasks/ingest/models.py
+++ b/pctasks/ingest/pctasks/ingest/models.py
@@ -99,7 +99,7 @@ class IngestTaskConfig(TaskDefinition):
         environment: Optional[Dict[str, str]] = None,
         options: Optional[IngestOptions] = None,
         ingest_settings: Optional[IngestSettings] = None,
-        add_service_principal: bool = True,
+        add_service_principal: bool = False,
     ) -> TaskDefinition:
         data = IngestTaskInput(
             content=content,
@@ -146,7 +146,7 @@ class IngestTaskConfig(TaskDefinition):
         environment: Optional[Dict[str, str]] = None,
         options: Optional[IngestOptions] = None,
         ingest_settings: Optional[IngestSettings] = None,
-        add_service_principal: bool = True,
+        add_service_principal: bool = False,
     ) -> TaskDefinition:
         if "collection" not in item:
             raise InvalidSTACException("Item is missing a collection.")
@@ -171,7 +171,7 @@ class IngestTaskConfig(TaskDefinition):
         environment: Optional[Dict[str, str]] = None,
         options: Optional[IngestOptions] = None,
         ingest_settings: Optional[IngestSettings] = None,
-        add_service_principal: bool = True,
+        add_service_principal: bool = False,
     ) -> TaskDefinition:
         if "id" not in collection:
             raise InvalidSTACException("Collection is missing an id.")
@@ -196,7 +196,7 @@ class IngestTaskConfig(TaskDefinition):
         environment: Optional[Dict[str, str]] = None,
         options: Optional[IngestOptions] = None,
         ingest_settings: Optional[IngestSettings] = None,
-        add_service_principal: bool = True,
+        add_service_principal: bool = False,
     ) -> TaskDefinition:
 
         return cls.create(
@@ -219,7 +219,7 @@ class IngestTaskConfig(TaskDefinition):
         environment: Optional[Dict[str, str]] = None,
         option: Optional[IngestOptions] = None,
         ingest_settings: Optional[IngestSettings] = None,
-        add_service_principal: bool = True,
+        add_service_principal: bool = False,
     ) -> TaskDefinition:
         return cls.create(
             task_id=NDJSON_TASK_ID,

--- a/pctasks/ingest_task/tests/test_items.py
+++ b/pctasks/ingest_task/tests/test_items.py
@@ -70,7 +70,8 @@ def test_ndjson_ingest():
 
 def test_ingest_ndjson_add_service_principal():
     result = IngestTaskConfig.from_ndjson(
-        ndjson_data=IngestNdjsonInput(ndjson_folder=NdjsonFolder(uri="test/"))
+        ndjson_data=IngestNdjsonInput(ndjson_folder=NdjsonFolder(uri="test/")),
+        add_service_principal=True,
     )
 
     assert result.environment["AZURE_TENANT_ID"] == "${{ secrets.task-tenant-id }}"
@@ -82,6 +83,7 @@ def test_ingest_ndjson_add_service_principal():
     result = IngestTaskConfig.from_ndjson(
         ndjson_data=IngestNdjsonInput(ndjson_folder=NdjsonFolder(uri="test/")),
         environment={"AZURE_TENANT_ID": "test"},
+        add_service_principal=True,
     )
     assert result.environment["AZURE_TENANT_ID"] == "test"
     assert result.environment["AZURE_CLIENT_ID"] == "${{ secrets.task-client-id }}"
@@ -91,7 +93,6 @@ def test_ingest_ndjson_add_service_principal():
 
     result = IngestTaskConfig.from_ndjson(
         ndjson_data=IngestNdjsonInput(ndjson_folder=NdjsonFolder(uri="test/")),
-        add_service_principal=False,
     )
     assert "AZURE_TENANT_ID" not in result.environment
     assert "AZURE_TENANT_ID" not in result.environment

--- a/pctasks/ingest_task/tests/test_items.py
+++ b/pctasks/ingest_task/tests/test_items.py
@@ -5,8 +5,8 @@ from pctasks.core.models.task import FailedTaskResult
 from pctasks.dev.mocks import MockTaskContext
 from pctasks.ingest.models import (
     IngestNdjsonInput,
-    IngestTaskInput,
     IngestTaskConfig,
+    IngestTaskInput,
     NdjsonFolder,
 )
 from pctasks.ingest_task.task import ingest_task

--- a/pctasks/ingest_task/tests/test_items.py
+++ b/pctasks/ingest_task/tests/test_items.py
@@ -3,7 +3,12 @@ import pathlib
 
 from pctasks.core.models.task import FailedTaskResult
 from pctasks.dev.mocks import MockTaskContext
-from pctasks.ingest.models import IngestNdjsonInput, IngestTaskInput
+from pctasks.ingest.models import (
+    IngestNdjsonInput,
+    IngestTaskInput,
+    IngestTaskConfig,
+    NdjsonFolder,
+)
 from pctasks.ingest_task.task import ingest_task
 from tests.conftest import ingest_test_environment
 
@@ -61,3 +66,33 @@ def test_ndjson_ingest():
         result = ingest_task.run(input=message_data, context=task_context)
 
         assert not isinstance(result, FailedTaskResult)
+
+
+def test_ingest_ndjson_add_service_principal():
+    result = IngestTaskConfig.from_ndjson(
+        ndjson_data=IngestNdjsonInput(ndjson_folder=NdjsonFolder(uri="test/"))
+    )
+
+    assert result.environment["AZURE_TENANT_ID"] == "${{ secrets.task-tenant-id }}"
+    assert result.environment["AZURE_CLIENT_ID"] == "${{ secrets.task-client-id }}"
+    assert (
+        result.environment["AZURE_CLIENT_SECRET"] == "${{ secrets.task-client-secret }}"
+    )
+
+    result = IngestTaskConfig.from_ndjson(
+        ndjson_data=IngestNdjsonInput(ndjson_folder=NdjsonFolder(uri="test/")),
+        environment={"AZURE_TENANT_ID": "test"},
+    )
+    assert result.environment["AZURE_TENANT_ID"] == "test"
+    assert result.environment["AZURE_CLIENT_ID"] == "${{ secrets.task-client-id }}"
+    assert (
+        result.environment["AZURE_CLIENT_SECRET"] == "${{ secrets.task-client-secret }}"
+    )
+
+    result = IngestTaskConfig.from_ndjson(
+        ndjson_data=IngestNdjsonInput(ndjson_folder=NdjsonFolder(uri="test/")),
+        add_service_principal=False,
+    )
+    assert "AZURE_TENANT_ID" not in result.environment
+    assert "AZURE_TENANT_ID" not in result.environment
+    assert "AZURE_TENANT_ID" not in result.environment


### PR DESCRIPTION
This changes the output of `pctasks ingest ndjsons` to include the commonly (always?) needed service principal credentials.

For example:

```
$ pctasks ingest ndjsons usgs-lcmap-conus-v13 blob://landcoverdata/lcmap-etl-data/lcmap-conus-v13/2023-01-12-full-3/items/all --workflow-id=lcmap-conus-v13-reingest
```

Will now produce

```yaml
name: Ingest NDJsons from blob://landcoverdata/lcmap-etl-data/lcmap-conus-v13/2023-01-12-full-3/items/all
jobs:
  ingest-items:
    id: ingest-items
    tasks:
    - id: ingest-ndjson
      image_key: ingest
      task: pctasks.ingest_task.task:ingest_task
      args:
        content:
          type: Ndjson
          ndjson_folder:
            uri: blob://landcoverdata/lcmap-etl-data/lcmap-conus-v13/2023-01-12-full-3/items/all
            extensions: []
        options:
          insert_group_size: 5000
          insert_only: false
      environment:
        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
      schema_version: 1.0.0
schema_version: 1.0.0
id: lcmap-conus-v13-reingest
dataset: microsoft/usgs-lcmap-conus-v13
```

The relevant change is to `jobs.ingest-items.tasks[0].environment`.