### PR TITLE
Allow imageKey table name override via settings

### DIFF
--- a/deployment/helm/deploy-values.template.yaml
+++ b/deployment/helm/deploy-values.template.yaml
@@ -50,6 +50,7 @@ pctasks:
       account_name: {{ tf.sa_account_name }}
       account_key: {{ tf.sa_account_key }}
       connection_string: {{ tf.sa_connection_string}}
+      image_key_table_name: "imagekeys"
 
     blob:
       account_url: {{ tf.sa_blob_account_url }}

--- a/deployment/helm/published/pctasks-server/templates/deployment.yaml
+++ b/deployment/helm/published/pctasks-server/templates/deployment.yaml
@@ -150,6 +150,8 @@ spec:
               value: "{{ .Values.pctasks.run.tables.account_name }}"
             - name: PCTASKS_RUN__TABLES_ACCOUNT_KEY
               value: "{{ .Values.pctasks.run.tables.account_key }}"
+            - name: PCTASKS_RUN__IMAGE_KEY_TABLE_NAME
+              value: "{{ .Values.pctasks.run.tables.image_key_table_name }}"
 
             ### Blobs
             - name: PCTASKS_RUN__BLOB_ACCOUNT_URL


### PR DESCRIPTION
## Description

The name of the Azure Storage Table used for image keys can be set via deployment. Still defaults to "imageKeys" if unset.