### PR TITLE
[goes-glm]: Added goes-18

### DIFF
--- a/datasets/goes/goes-glm/README.md
+++ b/datasets/goes/goes-glm/README.md
@@ -11,13 +11,12 @@ $ pctasks dataset process-items '${{ args.since }}' \
     -d datasets/goes/goes-glm/dataset.yaml \
     -c goes-glm \
     --workflow-id=goes-glm-update \
-    --target=green \
     --is-update-workflow \
     > datasets/goes/goes-glm/workflows/goes-glm-update.yaml
 ```
 
-As an optimization, I manually appended `2022` to the `prefix`. That will require updating in the new year. Longer-term pctasks should
-optionally do that dynamically from `since`. Likewise for `blue` with a `--workflow-id=goes-glm-update-blue`.
+As an optimization, I manually appended `2023` to the `prefix`. That will require updating in the new year. Longer-term pctasks should
+optionally do that dynamically from `since`.
 
 And registered with
 

--- a/datasets/goes/goes-glm/dataset.yaml
+++ b/datasets/goes/goes-glm/dataset.yaml
@@ -1,5 +1,5 @@
 id: goes_glm
-image: ${{ args.registry }}/pctasks-goes-glm:2022.10.31.0
+image: ${{ args.registry }}/pctasks-goes-glm:2023.2.7
 
 args:
 - registry
@@ -30,6 +30,16 @@ collections:
               depth: 2
       - uri: blob://goeseuwest/noaa-goes17/
         token: ${{ pc.get_token(goeseuwest, noaa-goes17) }}
+        chunks:
+          options:
+            ends_with: .nc
+            chunk_length: 10000
+          splits:
+            - prefix: GLM-L2-LCFA/
+              depth: 2
+
+      - uri: blob://goeseuwest/noaa-goes18/
+        token: ${{ pc.get_token(goeseuwest, noaa-goes18) }}
         chunks:
           options:
             ends_with: .nc

--- a/datasets/goes/goes-glm/requirements.txt
+++ b/datasets/goes/goes-glm/requirements.txt
@@ -1,1 +1,1 @@
-stactools-goes-glm==0.2.1
+stactools-goes-glm==0.2.3

--- a/datasets/goes/goes-glm/workflows/goes-glm-update.yaml
+++ b/datasets/goes/goes-glm/workflows/goes-glm-update.yaml
@@ -6,7 +6,8 @@ tokens:
         token: ${{ pc.get_token(goeseuwest, noaa-goes16) }}
       noaa-goes17:
         token: ${{ pc.get_token(goeseuwest, noaa-goes17) }}
-target_environment: green
+      noaa-goes18:
+        token: ${{ pc.get_token(goeseuwest, noaa-goes18) }}
 args:
 - registry
 - since
@@ -15,7 +16,7 @@ jobs:
     id: create-splits
     tasks:
     - id: create-splits
-      image: ${{ args.registry }}/pctasks-goes-glm:2022.11.3.0
+      image: ${{ args.registry }}/pctasks-goes-glm:2023.2.7
       code:
         src: datasets/goes/goes-glm/goes_glm.py
       task: goes_glm:GoesGlmCollection.create_splits_task
@@ -35,9 +36,20 @@ jobs:
             since: ${{ args.since }}
         - uri: blob://goeseuwest/noaa-goes17/
           splits:
-          - prefix: GLM-L2-LCFA/2023/
+          - p1refix: GLM-L2-LCFA/2023/
             depth: 2
           sas_token: ${{ pc.get_token(goeseuwest, noaa-goes17) }}
+          chunk_options:
+            chunk_length: 10000
+            ends_with: .nc
+            list_folders: false
+            chunk_file_name: uris-list
+            chunk_extension: .csv
+        - uri: blob://goeseuwest/noaa-goes18/
+          splits:
+          - prefix: GLM-L2-LCFA/2023/
+            depth: 2
+          sas_token: ${{ pc.get_token(goeseuwest, noaa-goes18) }}
           chunk_options:
             chunk_length: 10000
             ends_with: .nc
@@ -54,7 +66,7 @@ jobs:
     id: create-chunks
     tasks:
     - id: create-chunks
-      image: ${{ args.registry }}/pctasks-goes-glm:2022.11.3.0
+      image: ${{ args.registry }}/pctasks-goes-glm:2023.2.7
       code:
         src: datasets/goes/goes-glm/goes_glm.py
       task: pctasks.dataset.chunks.task:create_chunks_task
@@ -75,7 +87,7 @@ jobs:
     id: process-chunk
     tasks:
     - id: create-items
-      image: ${{ args.registry }}/pctasks-goes-glm:2022.11.3.0
+      image: ${{ args.registry }}/pctasks-goes-glm:2023.2.7
       code:
         src: datasets/goes/goes-glm/goes_glm.py
       task: goes_glm:GoesGlmCollection.create_items_task

--- a/pctasks/core/setup.py
+++ b/pctasks/core/setup.py
@@ -9,7 +9,7 @@ install_requires = [
     "azure-identity==1.*",
     "azure-storage-blob==12.9",  # Issues with 12.11 generating sas from account keys
     # https://github.com/microsoft/planetary-computer-tasks/issues/136
-    "azure-storage-queue>=12.*,<12.6",
+    "azure-storage-queue>=12.0.0",
     "azure-data-tables==12.*",
     "azure-cosmos==4.3.*",
     "pydantic>=1.9,<2.0.0",

--- a/pctasks/core/setup.py
+++ b/pctasks/core/setup.py
@@ -8,7 +8,8 @@ with open("README.md") as f:
 install_requires = [
     "azure-identity==1.*",
     "azure-storage-blob==12.9",  # Issues with 12.11 generating sas from account keys
-    "azure-storage-queue>=12.*",
+    # https://github.com/microsoft/planetary-computer-tasks/issues/136
+    "azure-storage-queue>=12.*,<12.6",
     "azure-data-tables==12.*",
     "azure-cosmos==4.3.*",
     "pydantic>=1.9,<2.0.0",


### PR DESCRIPTION
stactools-goes-glm==0.2.3 added support for goes-18. This bumps its version in our image and adds an entry to look for goes-glm assets in the `noaa-goes18` storage container.