### PR TITLE
[CI]: Mount the azure directory in deploy

### DIFF
--- a/scripts/cideploy
+++ b/scripts/cideploy
@@ -58,6 +58,7 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
         # Run deployment script
         ${DOCKER_COMPOSE} run --rm \
+            -v "$HOME/.azure":/root/.azure \
             deploy bin/deploy \
             -t "${TERRAFORM_DIR}"
     )


### PR DESCRIPTION
This mounts ~/.azure into the docker container doing the deployment. We now get credentials from the Azure CLI, which are stored in ~/.azure on the GitHub runner. By mounting the directory to `/root/.azure` on the docker container deploying things, it too has access to the Azure credentials from the azlogin action.