### PR TITLE
[packaging]: Use setuptools-scm to set versions

### DIFF
--- a/pctasks/cli/pctasks/cli/version.py
+++ b/pctasks/cli/pctasks/cli/version.py
@@ -1,1 +1,7 @@
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pctasks-cli")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/pctasks/cli/setup.py
+++ b/pctasks/cli/setup.py
@@ -46,5 +46,9 @@ setup(
     extras_require=extra_reqs,
     entry_points={
         'console_scripts': ['pctasks=pctasks.cli.cli:cli']
-    }
+    },
+    use_scm_version={
+        "root": "../..",
+    },
+    setup_requires=["setuptools_scm"],
 )

--- a/pctasks/client/pctasks/client/version.py
+++ b/pctasks/client/pctasks/client/version.py
@@ -1,1 +1,7 @@
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pctasks-cli")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/pctasks/client/setup.py
+++ b/pctasks/client/setup.py
@@ -42,4 +42,8 @@ setup(
     install_requires=install_requires,
     tests_require=extra_reqs["dev"],
     extras_require=extra_reqs,
+    use_scm_version={
+        "root": "../..",
+    },
+    setup_requires=["setuptools_scm"],
 )

--- a/pctasks/core/pctasks/core/version.py
+++ b/pctasks/core/pctasks/core/version.py
@@ -1,1 +1,7 @@
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pctasks-cli")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/pctasks/core/setup.py
+++ b/pctasks/core/setup.py
@@ -53,4 +53,8 @@ setup(
     install_requires=install_requires,
     tests_require=extra_reqs["dev"],
     extras_require=extra_reqs,
+    use_scm_version={
+        "root": "../..",
+    },
+    setup_requires=["setuptools_scm"],
 )

--- a/pctasks/dataset/pctasks/dataset/version.py
+++ b/pctasks/dataset/pctasks/dataset/version.py
@@ -1,1 +1,7 @@
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pctasks-cli")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/pctasks/dataset/setup.py
+++ b/pctasks/dataset/setup.py
@@ -45,4 +45,8 @@ setup(
     install_requires=install_requires,
     tests_require=extra_reqs["dev"],
     extras_require=extra_reqs,
+    use_scm_version={
+        "root": "../..",
+    },
+    setup_requires=["setuptools_scm"],
 )

--- a/pctasks/dev/pctasks/dev/version.py
+++ b/pctasks/dev/pctasks/dev/version.py
@@ -1,1 +1,7 @@
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pctasks-cli")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/pctasks/dev/setup.py
+++ b/pctasks/dev/setup.py
@@ -40,4 +40,8 @@ setup(
     install_requires=install_requires,
     extras_require=extra_reqs,
     entry_points={"console_scripts": ["pctasks-dev=pctasks.dev.cli:cli"]},
+    use_scm_version={
+        "root": "../..",
+    },
+    setup_requires=["setuptools_scm"],
 )

--- a/pctasks/ingest/pctasks/ingest/version.py
+++ b/pctasks/ingest/pctasks/ingest/version.py
@@ -1,1 +1,7 @@
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pctasks-cli")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/pctasks/ingest/setup.py
+++ b/pctasks/ingest/setup.py
@@ -45,4 +45,8 @@ setup(
     install_requires=install_requires,
     tests_require=extra_reqs["dev"],
     extras_require=extra_reqs,
+    use_scm_version={
+        "root": "../..",
+    },
+    setup_requires=["setuptools_scm"],
 )

--- a/pctasks/ingest_task/pctasks/ingest_task/version.py
+++ b/pctasks/ingest_task/pctasks/ingest_task/version.py
@@ -1,1 +1,7 @@
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pctasks-cli")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/pctasks/ingest_task/setup.py
+++ b/pctasks/ingest_task/setup.py
@@ -47,4 +47,8 @@ setup(
     install_requires=install_requires,
     tests_require=extra_reqs["dev"],
     extras_require=extra_reqs,
+    use_scm_version={
+        "root": "../..",
+    },
+    setup_requires=["setuptools_scm"],
 )

--- a/pctasks/notify/pctasks/notify/version.py
+++ b/pctasks/notify/pctasks/notify/version.py
@@ -1,1 +1,7 @@
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pctasks-cli")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/pctasks/notify/setup.py
+++ b/pctasks/notify/setup.py
@@ -43,4 +43,8 @@ setup(
     install_requires=install_requires,
     tests_require=extra_reqs["dev"],
     extras_require=extra_reqs,
+    use_scm_version={
+        "root": "../..",
+    },
+    setup_requires=["setuptools_scm"],
 )

--- a/pctasks/router/pctasks/router/version.py
+++ b/pctasks/router/pctasks/router/version.py
@@ -1,1 +1,7 @@
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pctasks-cli")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/pctasks/router/setup.py
+++ b/pctasks/router/setup.py
@@ -43,4 +43,8 @@ setup(
     install_requires=install_requires,
     tests_require=extra_reqs["dev"],
     extras_require=extra_reqs,
+    use_scm_version={
+        "root": "../..",
+    },
+    setup_requires=["setuptools_scm"],
 )

--- a/pctasks/run/pctasks/run/version.py
+++ b/pctasks/run/pctasks/run/version.py
@@ -1,1 +1,7 @@
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pctasks-cli")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/pctasks/run/setup.py
+++ b/pctasks/run/setup.py
@@ -49,4 +49,8 @@ setup(
     install_requires=install_requires,
     tests_require=extra_reqs["dev"],
     extras_require=extra_reqs,
+    use_scm_version={
+        "root": "../..",
+    },
+    setup_requires=["setuptools_scm"],
 )

--- a/pctasks/server/pctasks/server/version.py
+++ b/pctasks/server/pctasks/server/version.py
@@ -1,1 +1,7 @@
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pctasks-cli")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/pctasks/task/pctasks/task/version.py
+++ b/pctasks/task/pctasks/task/version.py
@@ -1,1 +1,7 @@
-__version__ = "0.1.0"
+from importlib.metadata import PackageNotFoundError, version
+
+try:
+    __version__ = version("pctasks-cli")
+except PackageNotFoundError:
+    # package is not installed
+    pass

--- a/pctasks/task/setup.py
+++ b/pctasks/task/setup.py
@@ -44,4 +44,8 @@ setup(
     install_requires=install_requires,
     tests_require=extra_reqs["dev"],
     extras_require=extra_reqs,
+    use_scm_version={
+        "root": "../..",
+    },
+    setup_requires=["setuptools_scm"],
 )


### PR DESCRIPTION
This adds setuptools-scm to dynamically set the package version based on the commit history. With this, we'll get a unique package version per commit pushed to main.