### PR TITLE
Fix status --watch poll rate; reduce the number of ComosDB client connections

### DIFF
--- a/pctasks/client/pctasks/client/runs/_status.py
+++ b/pctasks/client/pctasks/client/runs/_status.py
@@ -89,7 +89,7 @@ def workflow_status_cmd(
     if not watch:
         console.print(table)
     else:
-        with Live(table, refresh_per_second=poll_rate) as live:
+        with Live(table, refresh_per_second=float(1 / poll_rate)) as live:
             while not is_complete:
                 table, is_complete = get_table()
                 live.update(table)

--- a/pctasks/core/pctasks/core/storage/blob.py
+++ b/pctasks/core/pctasks/core/storage/blob.py
@@ -565,8 +565,8 @@ class BlobStorage(Storage):
                         bytes,
                         blob_data.readall(),
                     )
-        except azure.core.exceptions.ResourceNotFoundError:
-            raise FileNotFoundError(f"File {file_path} not found in {self}")
+        except azure.core.exceptions.ResourceNotFoundError as e:
+            raise FileNotFoundError(f"File {file_path} not found in {self}") from e
         except Exception as e:
             raise BlobStorageError(
                 f"Could not read text from {self.get_uri(file_path)}"


### PR DESCRIPTION
This fixes a bug where the poll rate for `pctasks runs status --watch` was mishandled; the default of "Poll once every 10 seconds" was being interpreted as "Poll 10 times every second". 

Also, consolidate the number of ComosDB connections created in the workflow executor. This passes container clients to threads in the thread pool rather than create new connections per thread. As far as I can tell and have tested, the client is thread safe, and there is text in the ComsosDB docs that suggests the number of client connections should be minimized.

Additionally, modified the standard exception inspection in "with_backoff" to recurse down into inner exceptions, and added some additional logic to catch 'connection reset by peer' errors. This is based on a transient error I saw fail a Task where the connection reset error was wrapped in an outer exception, so was not retried.