### PR TITLE
Consolidate Batch client usage and decrease API hits

### DIFF
--- a/deployment/bin/lib
+++ b/deployment/bin/lib
@@ -61,6 +61,14 @@ function render_values() {
 function cluster_login() {
     echo "Logging into the cluster..."
 
+    if [ -z "${RESOURCE_GROUP}" ]; then
+        RESOURCE_GROUP=$1
+    fi
+
+    if [ -z "${CLUSTER_NAME}" ]; then
+        CLUSTER_NAME=$2
+    fi
+
     az login --service-principal \
         --username ${ARM_CLIENT_ID} \
         --password ${ARM_CLIENT_SECRET} \

--- a/pctasks/core/pctasks/core/queues.py
+++ b/pctasks/core/pctasks/core/queues.py
@@ -71,8 +71,8 @@ class QueueService:
         def _get_clients(
             _conn_str: str = connection_string, _queue: str = queue_name
         ) -> Tuple[Optional[QueueServiceClient], QueueClient]:
-            service_client = QueueServiceClient.from_connection_string(
-                conn_str=_conn_str
+            service_client: QueueServiceClient = (
+                QueueServiceClient.from_connection_string(conn_str=_conn_str)
             )
             return (
                 service_client,

--- a/pctasks/core/setup.py
+++ b/pctasks/core/setup.py
@@ -9,7 +9,7 @@ install_requires = [
     "azure-identity==1.*",
     "azure-storage-blob==12.9",  # Issues with 12.11 generating sas from account keys
     # https://github.com/microsoft/planetary-computer-tasks/issues/136
-    "azure-storage-queue>=12.0.0",
+    "azure-storage-queue>=12.6.0",
     "azure-data-tables==12.*",
     "azure-cosmos==4.3.*",
     "pydantic>=1.9,<2.0.0",
@@ -20,7 +20,7 @@ install_requires = [
     "opencensus-ext-logging==0.1.1",
     "pyyaml>=5.3",
     "aiohttp==3.8.*",
-    "planetary-computer>=0.4.0"
+    "planetary-computer>=0.4.0",
 ]
 
 extra_reqs = {

--- a/pctasks/dev/pctasks/dev/azurite.py
+++ b/pctasks/dev/pctasks/dev/azurite.py
@@ -29,7 +29,7 @@ def setup_azurite() -> None:
 
     print("~ Setting up queues...")
 
-    queue_client = QueueServiceClient.from_connection_string(
+    queue_client: QueueServiceClient = QueueServiceClient.from_connection_string(
         get_azurite_connection_string()
     )
     existing_queues = [q.name for q in queue_client.list_queues()]

--- a/pctasks/run/pctasks/run/_cli.py
+++ b/pctasks/run/pctasks/run/_cli.py
@@ -80,15 +80,14 @@ def remote_cmd(
             workflow_args[split_args[0]] = split_args[1]
         submit_message.args = {**(submit_message.args or {}), **workflow_args}
 
-    runner = RemoteWorkflowExecutor(executor_config)
-
     if new_id:
         submit_message.run_id = uuid4().hex
 
-    if executor_config.cosmosdb_settings.is_cosmosdb_emulator():
-        # Prevent workflow run logs from being overrun by
-        # SSL warnings if using the Cosmos DB emulator
-        with ignore_ssl_warnings():
+    with RemoteWorkflowExecutor(executor_config) as runner:
+        if executor_config.cosmosdb_settings.is_cosmosdb_emulator():
+            # Prevent workflow run logs from being overrun by
+            # SSL warnings if using the Cosmos DB emulator
+            with ignore_ssl_warnings():
+                runner.execute_workflow(submit_message)
+        else:
             runner.execute_workflow(submit_message)
-    else:
-        runner.execute_workflow(submit_message)

--- a/pctasks/run/pctasks/run/batch/client.py
+++ b/pctasks/run/pctasks/run/batch/client.py
@@ -300,7 +300,7 @@ class BatchClient:
         client = self._ensure_client()
 
         tasks = list(client.task.list(job_id))
-        print(len(tasks))
+
         running_tasks = [
             cast(batchmodels.CloudTask, task)
             for task in tasks

--- a/pctasks/run/pctasks/run/settings.py
+++ b/pctasks/run/pctasks/run/settings.py
@@ -37,6 +37,7 @@ class BatchSettings(PCBaseModel):
     key: str
     default_pool_id: str
     submit_threads: int
+    cache_seconds: int = 5  # How long to cache batch API responses
 
     def get_batch_name(self) -> str:
         return urlparse(self.url).netloc.split(".")[0]
@@ -83,6 +84,7 @@ class RunSettings(PCTasksSettings):
     batch_key: Optional[str] = None
     batch_default_pool_id: Optional[str] = None
     batch_submit_threads: int = 0
+    batch_cache_seconds: int = 5  # How long to cache batch API responses
 
     # Argo
     argo_host: Optional[str] = None

--- a/pctasks/run/pctasks/run/task/argo.py
+++ b/pctasks/run/pctasks/run/task/argo.py
@@ -36,6 +36,12 @@ class ArgoTaskRunner(TaskRunner):
             host=argo_host, token=argo_token, namespace=settings.argo_namespace
         )
 
+    def __enter__(self) -> "ArgoTaskRunner":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        pass
+
     def prepare_task_info(
         self,
         dataset_id: str,

--- a/pctasks/run/pctasks/run/task/base.py
+++ b/pctasks/run/pctasks/run/task/base.py
@@ -16,6 +16,14 @@ class TaskRunner(ABC):
         self.settings = settings
 
     @abstractmethod
+    def __enter__(self) -> "TaskRunner":
+        pass
+
+    @abstractmethod
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        pass
+
+    @abstractmethod
     def prepare_task_info(
         self,
         dataset_id: str,

--- a/pctasks/run/pctasks/run/task/batch.py
+++ b/pctasks/run/pctasks/run/task/batch.py
@@ -5,8 +5,8 @@ from itertools import groupby
 from threading import Lock
 from typing import Any, Dict, List, Optional, Set, Tuple, Union
 
-import cachetools
 import azure.batch.models as batchmodels
+import cachetools
 
 from pctasks.core.models.run import TaskRunStatus
 from pctasks.core.models.task import TaskDefinition
@@ -74,7 +74,7 @@ class BatchTaskRunner(TaskRunner):
     def __init__(self, settings: RunSettings):
         super().__init__(settings)
         self._batch_client: Optional[BatchClient] = None
-        self.response_cache = cachetools.TTLCache(
+        self.response_cache: cachetools.Cache = cachetools.TTLCache(
             maxsize=100, ttl=self.settings.batch_cache_seconds
         )
 

--- a/pctasks/run/pctasks/run/task/local.py
+++ b/pctasks/run/pctasks/run/task/local.py
@@ -26,8 +26,14 @@ class LocalTaskRunner(TaskRunner):
     See the local-dev-endpoints service in the development environment.
     """
 
-    def __init__(self, local_dev_endpoints_url: str):
+    def __init__(self, local_dev_endpoints_url: str) -> None:
         self.local_dev_endpoints_url = local_dev_endpoints_url
+
+    def __enter__(self) -> "LocalTaskRunner":
+        return self
+
+    def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        pass
 
     def prepare_task_info(
         self,

--- a/pctasks/run/pctasks/run/workflow/executor/remote.py
+++ b/pctasks/run/pctasks/run/workflow/executor/remote.py
@@ -349,7 +349,7 @@ class RemoteWorkflowExecutor:
                     time.monotonic() - _last_runner_poll_time
                     > self.config.run_settings.task_poll_seconds
                 ):
-                    logger.info("Polling task runner for failed tasks...")
+
                     current_tasks = {
                         jps.partition_id: {
                             jps.current_task.task_id: jps.current_task.task_runner_id  # noqa: E501
@@ -362,11 +362,6 @@ class RemoteWorkflowExecutor:
                         current_tasks
                     )
                     _last_runner_poll_time = time.monotonic()
-                    total_failed = [len(ts) for ts in runner_failed_tasks.values()]
-                    if total_failed:
-                        logger.info(f"  - {sum(total_failed)} failed tasks found.")
-                    else:
-                        logger.info("  - No failed tasks found.")
 
                 for job_part_state in job_part_states:
                     part_id = job_part_state.job_part_submit_msg.partition_id

--- a/pctasks/run/pctasks/run/workflow/executor/remote.py
+++ b/pctasks/run/pctasks/run/workflow/executor/remote.py
@@ -181,6 +181,13 @@ class RemoteWorkflowExecutor:
         self.config = settings or WorkflowExecutorConfig.get()
         self.task_runner = get_task_runner(self.config.run_settings)
 
+    def __enter__(self) -> "RemoteWorkflowExecutor":
+        self.task_runner.__enter__()
+        return self
+
+    def __exit__(self, exc_type: Any, exc_value: Any, traceback: Any) -> None:
+        self.task_runner.__exit__(exc_type, exc_value, traceback)
+
     def create_job_partition_states(
         self,
         submit_msgs: Iterable[JobPartitionSubmitMessage],


### PR DESCRIPTION


This PR provides improvements on how PCTasks utilizes Azure Batch. This includes reducing the number of Batch clients created and the number of times the API is hit during a workflow run.

It modifies the RemoteWorkflowExecutor and TaskRunner to be context managers so that things like client connections can be managed by the class. The BatchTaskRunner now creates a batch client and uses a single client instead of creating and closing clients per call. This client is used across multiple threads, and thread safety from the client is assumed. This has been tested in multiple runs of a ~50 partition workflow.

In addition, a thread-locked cache is used to minimize the Batch API calls in the method that find failed Batch tasks. This method was being called once per thread, normally at roughly the same moment, and so would put a lot of pressure on the API. With the cache, the Batch API is hit at most a couple of times every 5 seconds for this purpose.
