### PR TITLE
[goes-glm]: Update to Python 3.11

### DIFF
--- a/datasets/goes/goes-glm/Dockerfile
+++ b/datasets/goes/goes-glm/Dockerfile
@@ -21,7 +21,7 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 # See https://github.com/mapbox/rasterio/issues/1289
 ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 
-# Install Python 3.8
+# Install Python 3.11
 RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh" \
    && bash "Mambaforge-$(uname)-$(uname -m).sh" -b -p /opt/conda \
    && rm -rf "Mambaforge-$(uname)-$(uname -m).sh"
@@ -29,7 +29,7 @@ RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/downloa
 ENV PATH /opt/conda/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/conda/lib/:$LD_LIBRARY_PATH
 
-RUN mamba install -y -c conda-forge python=3.8 gdal=3.3.3 pip setuptools cython numpy==1.21.5
+RUN mamba install -y -c conda-forge python=3.11 gdal pip setuptools cython numpy
 
 RUN python -m pip install --upgrade pip
 

--- a/datasets/goes/goes-glm/dataset.yaml
+++ b/datasets/goes/goes-glm/dataset.yaml
@@ -1,5 +1,5 @@
 id: goes_glm
-image: ${{ args.registry }}/pctasks-goes-glm:2023.2.7
+image: ${{ args.registry }}/pctasks-goes-glm:2023.2.23.0
 
 args:
 - registry

--- a/pctasks/core/pctasks/core/queues.py
+++ b/pctasks/core/pctasks/core/queues.py
@@ -76,7 +76,8 @@ class QueueService:
             )
             return (
                 service_client,
-                service_client.get_queue_client(
+                # https://github.com/Azure/azure-sdk-for-python/issues/28960
+                service_client.get_queue_client(  # type: ignore
                     queue=_queue,
                     message_encode_policy=BinaryBase64EncodePolicy(),
                     message_decode_policy=BinaryBase64DecodePolicy(),

--- a/pctasks/dev/pctasks/dev/azurite.py
+++ b/pctasks/dev/pctasks/dev/azurite.py
@@ -32,7 +32,8 @@ def setup_azurite() -> None:
     queue_client = QueueServiceClient.from_connection_string(
         get_azurite_connection_string()
     )
-    existing_queues = [q.name for q in queue_client.list_queues()]
+    # https://github.com/Azure/azure-sdk-for-python/issues/28960
+    existing_queues = [q.name for q in queue_client.list_queues()]  # type: ignore
     for queue_name in [
         DEFAULT_WORKFLOW_QUEUE_NAME,
         DEFAULT_INBOX_QUEUE_NAME,
@@ -41,7 +42,8 @@ def setup_azurite() -> None:
     ]:
         if queue_name not in existing_queues:
             print(f"~ ~ Creating {queue_name} queue...")
-            queue_client.create_queue(queue_name)
+            # https://github.com/Azure/azure-sdk-for-python/issues/28960
+            queue_client.create_queue(queue_name)  # type: ignore
 
     # Tables
 


### PR DESCRIPTION
Compared to 3.8, Python 3.11 has some fixes to deadlocks in ssl. This updates the version used in the goes-glm task.