### PR TITLE
Update deploy to avoid az login

### DIFF
--- a/deployment/bin/deploy
+++ b/deployment/bin/deploy
@@ -117,8 +117,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     # Deploy Terraform  #
     #####################
 
-    bin/azlogin
-
     source ${TERRAFORM_DIR}/env.sh
 
     require_env "DEPLOY_SECRETS_KV"


### PR DESCRIPTION
This will test whether GitHub is able to deploy with the mounted /root/.azure login credentials for deployment. Currently this line was attempting to login with the service principal, which is now unset.

