### PR TITLE
Change kv access settings

### DIFF
--- a/deployment/terraform/resources/keyvault.tf
+++ b/deployment/terraform/resources/keyvault.tf
@@ -1,6 +1,11 @@
 data "azurerm_key_vault" "pctasks" {
   name                = var.pctasks_task_kv
   resource_group_name = var.pctasks_task_kv_resource_group_name
+  network_acls {
+    default_action             = "Deny"
+    bypass                     = "AzureServices"
+    virtual_network_subnet_ids = [azurerm_subnet.k8snode_subnet.id]
+  }
 }
 
 resource "azurerm_key_vault_access_policy" "function_app" {


### PR DESCRIPTION
## Description

To disable public access to the KV of the pc-tasks, the kv terraform script was modified to only permit connections from trusted services, allowlisted IP addresses, and the vnet of the k8s nodes.

Fixes # (issue)

Compliance security of the pc tasks kvs

## Type of change

- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review