### PR TITLE
Use service principal in deployment

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -9,6 +9,10 @@ env:
   PCTASKS_COSMOSDB__URL: ${{ secrets.COSMOSDB_URL }}
   PCTASKS_COSMOSDB__KEY: ${{ secrets.COSMOSDB_KEY }}
   PCTASKS_COSMOSDB__TEST_CONTAINER_SUFFIX: ${{ github.run_id }}
+  AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+  AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
 permissions:
   id-token: write
@@ -23,13 +27,6 @@ jobs:
       - uses: actions/setup-python@v2
         with:
           python-version: "3.8"
-
-      - name: 'Az CLI login'
-        uses: azure/login@v1
-        with:
-            client-id: ${{ secrets.AZURE_CLIENT_ID }}
-            tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-            subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Install local dependencies
         run: ./scripts/install
@@ -77,13 +74,19 @@ jobs:
           esac
 
       - name: Log into the ACR (test)
-        run: az acr login -n pccomponentstest
+        env:
+          CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        run: docker login pccomponentstest.azurecr.io --username ${CLIENT_ID} --password ${CLIENT_SECRET}
 
       - name: Publish images (test)
         run: ./scripts/publish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}} --no-login
 
       - name: Log into the ACR
-        run: az acr login -n pccomponents
+        env:
+          CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+        run: docker login pccomponents.azurecr.io --username ${CLIENT_ID} --password ${CLIENT_SECRET}
 
       - name: Publish images
         run: ./scripts/publish --acr pccomponents --tag ${{steps.get_image_tag.outputs.tag}} --no-login

--- a/deployment/bin/deploy
+++ b/deployment/bin/deploy
@@ -32,12 +32,12 @@ Options:
 
 require_env "ARM_SUBSCRIPTION_ID"
 require_env "ARM_TENANT_ID"
-# require_env "ARM_CLIENT_ID"
-# require_env "ARM_CLIENT_SECRET"
+require_env "ARM_CLIENT_ID"
+require_env "ARM_CLIENT_SECRET"
 
-# require_env "AZURE_TENANT_ID"
-# require_env "AZURE_CLIENT_ID"
-# require_env "AZURE_CLIENT_SECRET"
+require_env "AZURE_TENANT_ID"
+require_env "AZURE_CLIENT_ID"
+require_env "AZURE_CLIENT_SECRET"
 
 ###################
 # Parse arguments #
@@ -116,6 +116,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     #####################
     # Deploy Terraform  #
     #####################
+
+    bin/azlogin
 
     source ${TERRAFORM_DIR}/env.sh
 

--- a/deployment/bin/lib
+++ b/deployment/bin/lib
@@ -61,7 +61,19 @@ function render_values() {
 function cluster_login() {
     echo "Logging into the cluster..."
 
-    # assume you've already logged in with the azure-cli
+    if [ -z "${RESOURCE_GROUP}" ]; then
+        RESOURCE_GROUP=$1
+    fi
+
+    if [ -z "${CLUSTER_NAME}" ]; then
+        CLUSTER_NAME=$2
+    fi
+
+    az login --service-principal \
+        --username ${ARM_CLIENT_ID} \
+        --password ${ARM_CLIENT_SECRET} \
+        --tenant ${ARM_TENANT_ID}
+
     az aks get-credentials \
         --resource-group ${RESOURCE_GROUP} \
         --name ${CLUSTER_NAME} \
@@ -74,7 +86,9 @@ function cluster_login() {
     # So we export to a kubeconfig file
     echo "Converting kubeconfig..."
     kubelogin convert-kubeconfig \
-        --login azurecli \
+        --login spn \
+        --client-id ${ARM_CLIENT_ID} \
+        --client-secret ${ARM_CLIENT_SECRET} \
         --kubeconfig=kubeconfig
     export KUBECONFIG=kubeconfig
 }

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -10,6 +10,13 @@ services:
       - TF_VAR_username=${USER}
       - ARM_SUBSCRIPTION_ID=${AZURE_SUBSCRIPTION_ID}
       - ARM_TENANT_ID=${AZURE_TENANT_ID}
+      - ARM_CLIENT_ID=${AZURE_CLIENT_ID}
+      - ARM_CLIENT_SECRET=${AZURE_CLIENT_SECRET}
+
+      # For Azure CLI
+      - AZURE_TENANT_ID=${AZURE_TENANT_ID}
+      - AZURE_CLIENT_ID=${AZURE_CLIENT_ID}
+      - AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}
 
       # Used in function deployment injected by GH Actions
       - GITHUB_TOKEN

--- a/deployment/terraform/dev/pools.tf
+++ b/deployment/terraform/dev/pools.tf
@@ -100,31 +100,6 @@ module "batch_pool_d3_v2_landsat" {
   subnet_id = module.resources.batch_nodepool_subnet
 }
 
-module "batch_pool_d3_v3_modis" {
-  source = "../batch_pool"
-
-  name                = "modis_pool"
-  resource_group_name = module.resources.resource_group
-  account_name        = module.resources.batch_account_name
-  display_name        = "modis_pool"
-  vm_size             = "STANDARD_D3_V2"
-  max_tasks_per_node  = 4
-
-  min_dedicated = 0
-  max_dedicated = 0
-
-  min_low_priority = var.min_low_priority
-  max_low_priority = 2
-
-  max_increase_per_scale = 50
-
-  acr_name = var.task_acr_name
-  acr_client_id = var.task_acr_sp_client_id
-  acr_client_secret = var.task_acr_sp_client_secret
-
-  subnet_id = module.resources.batch_nodepool_subnet
-}
-
 module "batch_pool_d3_v3_s2" {
   source = "../batch_pool"
 

--- a/deployment/terraform/staging/pools.tf
+++ b/deployment/terraform/staging/pools.tf
@@ -100,31 +100,6 @@ module "batch_pool_d3_v3_landsat" {
   subnet_id = module.resources.batch_nodepool_subnet
 }
 
-module "batch_pool_d3_v2_modis" {
-  source = "../batch_pool"
-
-  name                = "modis_pool"
-  resource_group_name = module.resources.resource_group
-  account_name        = module.resources.batch_account_name
-  display_name        = "modis_pool"
-  vm_size             = "STANDARD_D3_V2"
-  max_tasks_per_node  = 4
-
-  min_dedicated = 0
-  max_dedicated = 0
-
-  min_low_priority = var.min_low_priority
-  max_low_priority = 2
-
-  max_increase_per_scale = 50
-
-  acr_name = var.task_acr_name
-  acr_client_id = var.task_acr_sp_client_id
-  acr_client_secret = var.task_acr_sp_client_secret
-
-  subnet_id = module.resources.batch_nodepool_subnet
-}
-
 module "batch_pool_d3_v3_s2" {
   source = "../batch_pool"
 

--- a/scripts/cideploy
+++ b/scripts/cideploy
@@ -58,7 +58,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
         # Run deployment script
         ${DOCKER_COMPOSE} run --rm \
-            -v "$HOME/.azure":/root/.azure \
             deploy bin/deploy \
             -t "${TERRAFORM_DIR}"
     )


### PR DESCRIPTION
This reverts changes to using a federated identity, as that method hasn't been working for our CI deploy. Mounting
 the ~/.azure directory into the container did not work
 for containerized deployment. We'll continue to use
 a service principal for this.