### PR TITLE
Kv firewall

### DIFF
--- a/deployment/bin/deploy
+++ b/deployment/bin/deploy
@@ -115,6 +115,12 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
     bin/azlogin
 
+    require_env "DEPLOY_SECRETS_KV"
+    require_env "DEPLOY_SECRETS_KV_SECRET"
+    require_env "DEPLOY_SECRETS_KV_RG_NAME"
+    require_env "PCTASKS_TASK_KV"
+    require_env "PCTASKS_TASK_KV_RESOURCE_GROUP_NAME"
+    
     #########################
     # Add IP to KV firewall #
     #########################
@@ -127,8 +133,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
     source ${TERRAFORM_DIR}/env.sh
 
-    require_env "DEPLOY_SECRETS_KV"
-    require_env "DEPLOY_SECRETS_KV_SECRET"
 
     if [ -z "${SKIP_FETCH_TF_VARS}${SKIP_TF}${DEV_DEPLOY}" ]; then
 

--- a/deployment/bin/deploy
+++ b/deployment/bin/deploy
@@ -113,11 +113,17 @@ setup_env
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
+    bin/azlogin
+
+    #########################
+    # Add IP to KV firewall #
+    #########################
+
+    bin/kv_add_ip
+
     #####################
     # Deploy Terraform  #
     #####################
-
-    bin/azlogin
 
     source ${TERRAFORM_DIR}/env.sh
 
@@ -177,6 +183,12 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     gather_tf_output
 
     popd
+
+    ##############################
+    # Remove IP from KV firewall #
+    ##############################
+
+    bin/kv_rmv_ip
 
     ############################
     # Render Helm chart values #

--- a/deployment/bin/kv_add_ip
+++ b/deployment/bin/kv_add_ip
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+if [[ "${CI}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Add runner public IP to Key Vault firewall allow list
+"
+}
+
+while [[ "$#" -gt 0 ]]; do case $1 in
+    *)
+        usage "Unknown parameter passed: $1"
+        shift
+        shift
+        ;;
+    esac done
+
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+
+    runnerIpAddress=$(curl http://ipinfo.io/json | jq -r ".ip")
+
+    az keyvault network-rule add -g ${KEY_VAULT_RESOURCE_GROUP_NAME}  -n ${KEY_VAULT_NAME} --ip-address $runnerIpAddress
+
+fi

--- a/deployment/bin/kv_add_ip
+++ b/deployment/bin/kv_add_ip
@@ -26,6 +26,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
     runnerIpAddress=$(curl http://ipinfo.io/json | jq -r ".ip")
 
-    az keyvault network-rule add -g ${KEY_VAULT_RESOURCE_GROUP_NAME}  -n ${KEY_VAULT_NAME} --ip-address $runnerIpAddress
+    az keyvault network-rule add -g ${DEPLOY_SECRETS_KV_RG_NAME}  -n ${DEPLOY_SECRETS_KV} --ip-address $runnerIpAddress
+
+    az keyvault network-rule add -g ${PCTASKS_TASK_KV_RESOURCE_GROUP_NAME}  -n ${PCTASKS_TASK_KV} --ip-address $runnerIpAddress
 
 fi

--- a/deployment/bin/kv_rmv_ip
+++ b/deployment/bin/kv_rmv_ip
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+if [[ "${CI}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Remove runner public IP from Key Vault firewall allow list
+"
+}
+
+while [[ "$#" -gt 0 ]]; do case $1 in
+    *)
+        usage "Unknown parameter passed: $1"
+        shift
+        shift
+        ;;
+    esac done
+
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+
+    runnerIpAddress=$(curl http://ipinfo.io/json | jq -r ".ip")
+
+    az keyvault network-rule remove -g ${KEY_VAULT_RESOURCE_GROUP_NAME}  -n ${KEY_VAULT_NAME} --ip-address $runnerIpAddress
+
+fi

--- a/deployment/bin/kv_rmv_ip
+++ b/deployment/bin/kv_rmv_ip
@@ -26,6 +26,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
     runnerIpAddress=$(curl http://ipinfo.io/json | jq -r ".ip")
 
-    az keyvault network-rule remove -g ${KEY_VAULT_RESOURCE_GROUP_NAME}  -n ${KEY_VAULT_NAME} --ip-address $runnerIpAddress
+    az keyvault network-rule remove -g ${DEPLOY_SECRETS_KV_RG_NAME}  -n ${DEPLOY_SECRETS_KV} --ip-address $runnerIpAddress
+
+    az keyvault network-rule remove -g ${PCTASKS_TASK_KV_RESOURCE_GROUP_NAME}  -n ${PCTASKS_TASK_KV} --ip-address $runnerIpAddress
 
 fi

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -15,10 +15,6 @@ services:
       - GITHUB_TOKEN
       - GITHUB_REPOSITORY
       - GITHUB_ACTOR
-
-      # Used to open KV firewall for accessing tf.secrets
-      - KEY_VAULT_NAME
-      - KEY_VAULT_RESOURCE_GROUP_NAME
     working_dir: /opt/src/deployment
     volumes:
       - ../deployment:/opt/src/deployment

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -16,6 +16,9 @@ services:
       - GITHUB_REPOSITORY
       - GITHUB_ACTOR
 
+      # Used to open KV firewall for accessing tf.secrets
+      - KEY_VAULT_NAME
+      - KEY_VAULT_RESOURCE_GROUP_NAME
     working_dir: /opt/src/deployment
     volumes:
       - ../deployment:/opt/src/deployment

--- a/deployment/terraform/dev/env.sh
+++ b/deployment/terraform/dev/env.sh
@@ -2,3 +2,7 @@
 
 export DEPLOY_SECRETS_KV=pc-test-deploy-secrets
 export DEPLOY_SECRETS_KV_SECRET=pctasks-test-tfvars-rob
+export DEPLOY_SECRETS_KV_RG_NAME=pc-test-manual-resources
+
+export PCTASKS_TASK_KV=
+export PCTASKS_TASK_KV_RESOURCE_GROUP_NAME=

--- a/deployment/terraform/staging/env.sh
+++ b/deployment/terraform/staging/env.sh
@@ -2,3 +2,7 @@
 
 export DEPLOY_SECRETS_KV=pc-test-deploy-secrets
 export DEPLOY_SECRETS_KV_SECRET=pctasks-test-tfvars-staging
+export DEPLOY_SECRETS_KV_RG_NAME=pc-test-manual-resources
+
+export PCTASKS_TASK_KV=kv-pctaskstest-staging
+export PCTASKS_TASK_KV_RESOURCE_GROUP_NAME=rg-pctaskstest-staging-westeurope


### PR DESCRIPTION
## Description

During [deploy](https://github.com/microsoft/planetary-computer-tasks/blob/main/deployment/bin/deploy), terraform requires access to a KV to retrieve secrets from two different Key Vaults ([1](https://github.com/microsoft/planetary-computer-tasks/blob/0f47e4f88062b62f547f28c44b6195952996ffc2/deployment/terraform/resources/keyvault.tf#L1-L42) & [2](https://github.com/microsoft/planetary-computer-tasks/blob/0f47e4f88062b62f547f28c44b6195952996ffc2/deployment/terraform/resources/keyvault.tf#L44-L59)). Said KVs have to update their firewall rule to only **"Allow public access from specific virtual networks and IP addresses"**.

The current changes are meant to authenticate as an Azure Service Principal and include the current runner public IP into the KVs firewall allow list.
Once the task is done, the IP is removed.

Both of the KVs names and their RG names are set as env variables over their respective environments [env.sh](https://github.com/microsoft/planetary-computer-tasks/blob/044be53b4df1a7e591bad8c17b506eeda8596f38/deployment/terraform/staging/env.sh#L3-L8).

#### Fixes # Security Scanning Services - Compliance: Key Vault must have public access disabled.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

TBD

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)