### PR TITLE
Add ESA WorldCover

### DIFF
--- a/datasets/esa-worldcover/Dockerfile
+++ b/datasets/esa-worldcover/Dockerfile
@@ -1,0 +1,74 @@
+FROM ubuntu:20.04
+
+# Setup timezone info
+ENV TZ=UTC
+
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+RUN apt-get update && apt-get install -y software-properties-common
+
+RUN add-apt-repository ppa:ubuntugis/ppa && \
+    apt-get update && \
+    apt-get install -y build-essential python3-dev python3-pip \
+    jq unzip ca-certificates wget curl git && \
+    apt-get autoremove && apt-get autoclean && apt-get clean
+
+RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
+
+# See https://github.com/mapbox/rasterio/issues/1289
+ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+
+# Install Python 3.8
+RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh" \
+    && bash "Mambaforge-$(uname)-$(uname -m).sh" -b -p /opt/conda \
+    && rm -rf "Mambaforge-$(uname)-$(uname -m).sh"
+
+ENV PATH /opt/conda/bin:$PATH
+ENV LD_LIBRARY_PATH /opt/conda/lib/:$LD_LIBRARY_PATH
+
+RUN mamba install -y -c conda-forge python=3.8 gdal=3.3.3 pip setuptools cython numpy==1.21.5
+
+RUN python -m pip install --upgrade pip
+
+# Install common packages
+COPY requirements-task-base.txt /tmp/requirements.txt
+RUN python -m pip install --no-build-isolation -r /tmp/requirements.txt
+
+#
+# Copy and install packages
+#
+
+COPY pctasks/core /opt/src/pctasks/core
+RUN cd /opt/src/pctasks/core && \
+    pip install .
+
+COPY pctasks/cli /opt/src/pctasks/cli
+RUN cd /opt/src/pctasks/cli && \
+    pip install .
+
+COPY pctasks/task /opt/src/pctasks/task
+RUN cd /opt/src/pctasks/task && \
+    pip install .
+
+COPY pctasks/client /opt/src/pctasks/client
+RUN cd /opt/src/pctasks/client && \
+    pip install .
+
+COPY pctasks/ingest /opt/src/pctasks/ingest
+RUN cd /opt/src/pctasks/ingest && \
+    pip install .
+
+COPY pctasks/dataset /opt/src/pctasks/dataset
+RUN cd /opt/src/pctasks/dataset && \
+    pip install .
+
+COPY ./datasets/esa-worldcover/requirements.txt /opt/src/datasets/esa-worldcover/requirements.txt
+RUN python3 -m pip install -r /opt/src/datasets/esa-worldcover/requirements.txt
+
+# Setup Python Path to allow import of test modules
+ENV PYTHONPATH=/opt/src:$PYTHONPATH
+
+WORKDIR /opt/src

--- a/datasets/esa-worldcover/README.md
+++ b/datasets/esa-worldcover/README.md
@@ -1,0 +1,9 @@
+# planetary-computer-tasks dataset: esa-worldcover
+
+## Building the Docker image
+
+To build and push a custom docker image to our container registry:
+
+```shell
+az acr build -r {the registry} --subscription {the subscription} -t pctasks-esa-worldcover:latest -f datasets/esa-worldcover/Dockerfile .
+```

--- a/datasets/esa-worldcover/collection/description.md
+++ b/datasets/esa-worldcover/collection/description.md
@@ -1,0 +1,15 @@
+The European Space Agency (ESA) [WorldCover](https://esa-worldcover.org/en) product provides global land cover maps for the years 2020 and 2021 at 10 meter resolution based on the combination of [Sentinel-1](https://sentinel.esa.int/web/sentinel/missions/sentinel-1) radar data and [Sentinel-2](https://sentinel.esa.int/web/sentinel/missions/sentinel-2) imagery. The discrete classification maps provide 11 classes defined using the Land Cover Classification System (LCCS) developed by the United Nations (UN) Food and Agriculture Organization (FAO). The map images are stored in [cloud-optimized GeoTIFF](https://www.cogeo.org/) format.
+
+The WorldCover product is developed by a consortium of European service providers and research organizations. [VITO](https://remotesensing.vito.be/) (Belgium) is the prime contractor of the WorldCover consortium together with [Brockmann Consult](https://www.brockmann-consult.de/) (Germany), [CS SI](https://www.c-s.fr/) (France), [Gamma Remote Sensing AG](https://www.gamma-rs.ch/) (Switzerland), [International Institute for Applied Systems Analysis](https://www.iiasa.ac.at/) (Austria), and [Wageningen University](https://www.wur.nl/nl/Wageningen-University.htm) (The Netherlands).
+
+Two versions of the WorldCover product are available:
+
+- WorldCover 2020 produced using v100 of the algorithm
+  - [WorldCover 2020 v100 User Manual](https://esa-worldcover.s3.eu-central-1.amazonaws.com/v100/2020/docs/WorldCover_PUM_V1.0.pdf)
+  - [WorldCover 2020 v100 Validation Report]((<https://esa-worldcover.s3.eu-central-1.amazonaws.com/v100/2020/docs/WorldCover_PVR_V1.1.pdf>))
+
+- WorldCover 2021 produced using v200 of the algorithm
+  - [WorldCover 2021 v200 User Manual]((<https://esa-worldcover.s3.eu-central-1.amazonaws.com/v200/2021/docs/WorldCover_PUM_V2.0.pdf>))
+  - [WorldCover 2021 v200 Validaton Report]((<https://esa-worldcover.s3.eu-central-1.amazonaws.com/v200/2021/docs/WorldCover_PVR_V2.0.pdf>))
+
+Since the WorldCover maps for 2020 and 2021 were generated with different algorithm versions (v100 and v200, respectively), changes between the maps include both changes in real land cover and changes due to the used algorithms.

--- a/datasets/esa-worldcover/collection/template.json
+++ b/datasets/esa-worldcover/collection/template.json
@@ -1,0 +1,268 @@
+{
+    "stac_version": "1.0.0",
+    "type": "Collection",
+    "id": "esa-worldcover",
+    "title": "ESA WorldCover",
+    "description": "{{ collection.description }}",
+    "license": "CC-BY-4.0",
+    "links": [
+        {
+            "rel": "license",
+            "href": "https://spdx.org/licenses/CC-BY-4.0.html",
+            "type": "text/html",
+            "title": "Creative Commons Attribution 4.0 International License"
+        },
+        {
+            "rel": "cite-as",
+            "href": "https://doi.org/10.5281/zenodo.5571936 ",
+            "type": "text/html",
+            "title": "2020 Data DOI"
+        },
+        {
+            "rel": "cite-as",
+            "href": "https://doi.org/10.5281/zenodo.7254221",
+            "type": "text/html",
+            "title": "2021 Data DOI"
+        },
+        {
+            "rel": "about",
+            "href": "https://esa-worldcover.s3.amazonaws.com/v100/2020/docs/WorldCover_PUM_V1.0.pdf",
+            "type": "application/pdf",
+            "title": "2020 Product Version 1.0.0 User Manual"
+        },
+        {
+            "rel": "about",
+            "href": "https://esa-worldcover.s3.eu-central-1.amazonaws.com/v200/2021/docs/WorldCover_PUM_V2.0.pdf",
+            "type": "application/pdf",
+            "title": "2021 Product Version 2.0.0 User Manual"
+        },
+        {
+            "rel": "about",
+            "href": "https://worldcover2020.esa.int/data/docs/WorldCover_PVR_V1.1.pdf",
+            "type": "application/pdf",
+            "title": "2020 Product Version 1.0.0 Validation Report"
+        },
+        {
+            "rel": "about",
+            "href": "https://esa-worldcover.s3.eu-central-1.amazonaws.com/v200/2021/docs/WorldCover_PVR_V2.0.pdf",
+            "type": "application/pdf",
+            "title": "2021 Product Version 2.0.0 Validation Report"
+        }
+    ],
+    "stac_extensions": [
+        "https://stac-extensions.github.io/item-assets/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/raster/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/classification/v1.0.0/schema.json",
+        "https://stac-extensions.github.io/table/v1.2.0/schema.json"
+    ],
+    "keywords": [
+        "Global",
+        "Land Cover",
+        "Sentinel",
+        "ESA"
+    ],
+    "msft:short_description": "Global land cover product at 10 meter resolution based on Sentinel-1 and Sentinel-2 data",
+    "msft:storage_account": "ai4edataeuwest",
+    "msft:container": "esa-worldcover",
+    "providers": [
+        {
+            "name": "ESA",
+            "roles": [
+                "licensor",
+                "producer"
+            ],
+            "url": "https://esa-worldcover.org"
+        },
+        {
+            "name": "ESA WorldCover Consortium",
+            "description": "The WorldCover product is developed by a consortium led by VITO Remote Sensing together with partners Brockmann Consult, CS SI, Gamma Remote Sensing AG, IIASA and Wageningen University",
+            "roles": [
+                "processor"
+            ],
+            "url": "https://esa-worldcover.org"
+        },
+        {
+            "name": "Microsoft",
+            "roles": [
+                "host"
+            ],
+            "url": "https://planetarycomputer.microsoft.com"
+        }
+    ],
+    "assets": {
+        "thumbnail": {
+            "title": "ESA WorldCover thumbnail",
+            "href": "https://ai4edatasetspublicassets.blob.core.windows.net/assets/pc_thumbnails/esa-worldcover-thumb.png",
+            "type": "image/png",
+            "roles": [
+                "thumbnail"
+            ]
+        },
+        "geoparquet-items": {
+            "href": "abfs://items/esa-worldcover.parquet",
+            "title": "GeoParquet STAC items",
+            "description": "Snapshot of the collection's STAC items exported to GeoParquet format.",
+            "type": "application/x-parquet",
+            "roles": [
+                "stac-items"
+            ],
+            "table:storage_options": {
+                "account_name": "pcstacitems"
+            },
+            "msft:partition_info": {
+                "is_partitioned": false
+            }
+        }
+    },
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -180.0,
+                    -60.0,
+                    180.0,
+                    82.75
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2020-01-01T00:00:00Z",
+                    "2021-12-31T23:59:59Z"
+                ]
+            ]
+        }
+    },
+    "summaries": {
+        "platform": [
+            "sentinel-1a",
+            "sentinel-1b",
+            "sentinel-2a",
+            "sentinel-2b"
+        ],
+        "instruments": [
+            "c-sar",
+            "msi"
+        ],
+        "mission": [
+            "sentinel-1",
+            "sentinel-2"
+        ],
+        "esa_worldcover:product_version": [
+            "1.0.0",
+            "2.0.0"
+        ]
+    },
+    "item_assets": {
+        "map": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Land Cover Classes",
+            "description": "Discrete classification according to the Land Cover Classification System scheme developed by the United Nations Food and Agriculture Organization",
+            "classification:classes": [
+                {
+                    "value": 10,
+                    "description": "Tree cover",
+                    "color-hint": "006400"
+                },
+                {
+                    "value": 20,
+                    "description": "Shrubland",
+                    "color-hint": "FFBB22"
+                },
+                {
+                    "value": 30,
+                    "description": "Grassland",
+                    "color-hint": "FFFF4C"
+                },
+                {
+                    "value": 40,
+                    "description": "Cropland",
+                    "color-hint": "F096FF"
+                },
+                {
+                    "value": 50,
+                    "description": "Built-up",
+                    "color-hint": "FA0000"
+                },
+                {
+                    "value": 60,
+                    "description": "Bare / sparse vegetation",
+                    "color-hint": "B4B4B4"
+                },
+                {
+                    "value": 70,
+                    "description": "Snow and ice",
+                    "color-hint": "F0F0F0"
+                },
+                {
+                    "value": 80,
+                    "description": "Permanent water bodies",
+                    "color-hint": "0064C8"
+                },
+                {
+                    "value": 90,
+                    "description": "Herbaceous wetland",
+                    "color-hint": "0096A0"
+                },
+                {
+                    "value": 95,
+                    "description": "Mangroves",
+                    "color-hint": "00CF75"
+                },
+                {
+                    "value": 100,
+                    "description": "Moss and lichen",
+                    "color-hint": "FAE6A0"
+                }
+            ],
+            "raster:bands": [
+                {
+                    "name": "Band1",
+                    "description": "Classification values",
+                    "nodata": 0,
+                    "sampling": "area",
+                    "data_type": "uint8",
+                    "spatial_resolution": 10
+                }
+            ],
+            "roles": [
+                "data"
+            ]
+        },
+        "input_quality": {
+            "type": "image/tiff; application=geotiff; profile=cloud-optimized",
+            "title": "Classification Input Data Quality",
+            "description": "Per pixel quality indicator showing the quality of the input data.",
+            "raster:bands": [
+                {
+                    "name": "Band1",
+                    "description": "Number of Sentinel-1 GAMMA0 observations used in the classification workflow",
+                    "nodata": -1,
+                    "sampling": "area",
+                    "data_type": "int16",
+                    "spatial_resolution": 60
+                },
+                {
+                    "name": "Band2",
+                    "description": "Number of Sentinel-2 L2A observations used in the classification workflow",
+                    "nodata": -1,
+                    "sampling": "area",
+                    "data_type": "int16",
+                    "spatial_resolution": 60
+                },
+                {
+                    "name": "Band3",
+                    "description": "Percentage (0-100) of invalid S2 observations discarded in the classification workflow (after cloud and cloud shadow filtering)",
+                    "nodata": -1,
+                    "sampling": "area",
+                    "data_type": "int16",
+                    "spatial_resolution": 60
+                }
+            ],
+            "roles": [
+                "metadata"
+            ]
+        }
+    }
+}

--- a/datasets/esa-worldcover/collection/template.json
+++ b/datasets/esa-worldcover/collection/template.json
@@ -64,6 +64,7 @@
     "msft:short_description": "Global land cover product at 10 meter resolution based on Sentinel-1 and Sentinel-2 data",
     "msft:storage_account": "ai4edataeuwest",
     "msft:container": "esa-worldcover",
+    "msft:region": "westeurope",
     "providers": [
         {
             "name": "ESA",

--- a/datasets/esa-worldcover/dataset.yaml
+++ b/datasets/esa-worldcover/dataset.yaml
@@ -1,0 +1,30 @@
+id: esa-worldcover
+# image: ${{ args.registry }}/pctasks-esa-worldcover:latest
+image: ${{ args.registry }}/pctasks-task-base:latest
+
+args:
+  - registry
+
+code:
+  src: ${{ local.path(./esa_worldcover.py) }}
+  requirements: ${{ local.path(./requirements.txt) }}
+
+environment:
+  AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+  AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+  AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+
+collections:
+  - id: esa-worldcover
+    template: ${{ local.path(./collection) }}
+    class: esa_worldcover:ESAWorldCoverCollection
+    asset_storage:
+      - uri: blob://ai4edataeuwest/esa-worldcover/
+        chunks:
+          options:
+            extensions: [.tif]
+            name_starts_with: v200/2021/map
+            chunk_length: 5
+            limit: 5
+    chunk_storage:
+      uri: blob://ai4edataeuwest/esa-worldcover-etl-data/pctasks/

--- a/datasets/esa-worldcover/dataset.yaml
+++ b/datasets/esa-worldcover/dataset.yaml
@@ -21,8 +21,11 @@ collections:
         chunks:
           options:
             extensions: [.tif]
+            # The 'name_starts_with' filter will run a single year only. This
+            # is helpful since this is an annual product -> next year we can
+            # update this field and create only the items needed.
             name_starts_with: v200/2021/map
-            chunk_length: 200
-            limit: 3000
+            chunk_length: 20
+            limit: 40
     chunk_storage:
       uri: blob://ai4edataeuwest/esa-worldcover-etl-data/pctasks/

--- a/datasets/esa-worldcover/dataset.yaml
+++ b/datasets/esa-worldcover/dataset.yaml
@@ -1,24 +1,16 @@
 id: esa-worldcover
 image: ${{ args.registry }}/pctasks-esa-worldcover:latest
-# image: ${{ args.registry }}/pctasks-task-base:latest
 
 args:
   - registry
 
 code:
   src: ${{ local.path(./esa_worldcover.py) }}
-#   requirements: ${{ local.path(./requirements.txt) }}
 
 environment:
   AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
   AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
   AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
-
-# task_config:
-#   esa-worldcover:
-#     create-items:
-#       tags:
-#         batch_pool_id: high_memory_pool
 
 collections:
   - id: esa-worldcover

--- a/datasets/esa-worldcover/dataset.yaml
+++ b/datasets/esa-worldcover/dataset.yaml
@@ -14,11 +14,11 @@ environment:
   AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
   AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
 
-task_config:
-  esa-worldcover:
-    create-items:
-      tags:
-        batch_pool_id: high_memory_pool
+# task_config:
+#   esa-worldcover:
+#     create-items:
+#       tags:
+#         batch_pool_id: high_memory_pool
 
 collections:
   - id: esa-worldcover
@@ -29,8 +29,8 @@ collections:
         chunks:
           options:
             extensions: [.tif]
-            name_starts_with: v100/2020/map
-            chunk_length: 5
-            limit: 5
+            name_starts_with: v200/2021/map
+            chunk_length: 200
+            limit: 3000
     chunk_storage:
       uri: blob://ai4edataeuwest/esa-worldcover-etl-data/pctasks/

--- a/datasets/esa-worldcover/dataset.yaml
+++ b/datasets/esa-worldcover/dataset.yaml
@@ -24,8 +24,8 @@ collections:
             # The 'name_starts_with' filter will run a single year only. This
             # is helpful since this is an annual product -> next year we can
             # update this field and create only the items needed.
-            name_starts_with: v200/2021/map
-            chunk_length: 500
+            name_starts_with: v100/2020/map
+            chunk_length: 200
             # limit: 40
     chunk_storage:
       uri: blob://ai4edataeuwest/esa-worldcover-etl-data/pctasks/

--- a/datasets/esa-worldcover/dataset.yaml
+++ b/datasets/esa-worldcover/dataset.yaml
@@ -1,18 +1,24 @@
 id: esa-worldcover
-# image: ${{ args.registry }}/pctasks-esa-worldcover:latest
-image: ${{ args.registry }}/pctasks-task-base:latest
+image: ${{ args.registry }}/pctasks-esa-worldcover:latest
+# image: ${{ args.registry }}/pctasks-task-base:latest
 
 args:
   - registry
 
 code:
   src: ${{ local.path(./esa_worldcover.py) }}
-  requirements: ${{ local.path(./requirements.txt) }}
+#   requirements: ${{ local.path(./requirements.txt) }}
 
 environment:
   AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
   AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
   AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+
+task_config:
+  esa-worldcover:
+    create-items:
+      tags:
+        batch_pool_id: high_memory_pool
 
 collections:
   - id: esa-worldcover
@@ -23,7 +29,7 @@ collections:
         chunks:
           options:
             extensions: [.tif]
-            name_starts_with: v200/2021/map
+            name_starts_with: v100/2020/map
             chunk_length: 5
             limit: 5
     chunk_storage:

--- a/datasets/esa-worldcover/dataset.yaml
+++ b/datasets/esa-worldcover/dataset.yaml
@@ -25,7 +25,7 @@ collections:
             # is helpful since this is an annual product -> next year we can
             # update this field and create only the items needed.
             name_starts_with: v200/2021/map
-            chunk_length: 20
-            limit: 40
+            chunk_length: 500
+            # limit: 40
     chunk_storage:
       uri: blob://ai4edataeuwest/esa-worldcover-etl-data/pctasks/

--- a/datasets/esa-worldcover/esa_worldcover.py
+++ b/datasets/esa-worldcover/esa_worldcover.py
@@ -1,9 +1,16 @@
 import logging
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import List, Union
+from typing import List, Optional, Union
 
+import numpy as np
+import numpy.typing as npt
 import pystac
+import rasterio
+from shapely.geometry import shape
+from shapely.geometry.multipolygon import MultiPolygon
+from shapely.geometry.polygon import Polygon
+from stactools.core.utils.raster_footprint import RasterFootprint
 from stactools.esa_worldcover.stac import create_item
 
 from pctasks.core.models.task import WaitTaskResult
@@ -16,6 +23,37 @@ handler.setLevel(logging.INFO)
 logger = logging.getLogger(__name__)
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
+
+
+# This subclass is a workaround for node out-of-memory failures when computing
+# the data mask (the worldcover tiles are large: 36,000x36,000 pixels). We
+# bypass the mask creation and use the mask offered by rasterio. Since rasterio
+# masks use a valid data value of 255 rather than 1, we also override the
+# `data_extent` method. We do not convert the rasterio mask valid data value of
+# 255 to 1, as the conversion logic (np.where()) is the same as that which
+# causes the out-of-memory failure.
+#
+# This subclass may eventually be pushed to the stactools package.
+class RioMaskRasterFootprint(RasterFootprint):
+    def data_mask(self) -> npt.NDArray[np.uint8]:
+        # we are passing rasterio masks as the data array
+        return self.data_array
+
+    def data_extent(self, mask: npt.NDArray[np.uint8]) -> Optional[Polygon]:
+        data_polygons = [
+            shape(polygon_dict)
+            for polygon_dict, region_value in rasterio.features.shapes(
+                mask, transform=self.transform
+            )
+            if region_value == 255  # rasterio masks use 255 (not 1)
+        ]
+        if not data_polygons:
+            return None
+        elif len(data_polygons) == 1:
+            polygon = data_polygons[0]
+        else:
+            polygon = MultiPolygon(data_polygons).convex_hull
+        return polygon
 
 
 class ESAWorldCoverCollection(Collection):
@@ -31,16 +69,29 @@ class ESAWorldCoverCollection(Collection):
             tmp_map_path = str(Path(tmp_dir, map_name))
 
             quality_name = map_name.replace("_Map.tif", "_InputQuality.tif")
-            quality_path = str(Path(map_path).parent.parent / "input_quality" / quality_name)
+            quality_path = str(
+                Path(map_path).parent.parent / "input_quality" / quality_name
+            )
             logger.info(f"quality path = {quality_path}")
             tmp_quality_path = str(Path(tmp_dir, quality_name))
 
             storage.download_file(map_path, tmp_map_path)
             storage.download_file(quality_path, tmp_quality_path)
 
-            item = create_item(
-                map_href=tmp_map_path, include_quality_asset=True, raster_footprint=True
-            )
+            item = create_item(map_href=tmp_map_path, include_quality_asset=True)
+
+            with rasterio.open(tmp_map_path) as src:
+                assert src.nodata == 0
+                footprint = RioMaskRasterFootprint(
+                    data_array=src.read_masks(1),
+                    crs=src.crs,
+                    transform=src.transform,
+                    densification_distance=0.001,  # roughly 100 meters (10 pixels)
+                    simplify_tolerance=0.0001,  # roughly 10 meters (1 pixel)
+                    no_data=src.nodata,
+                ).footprint()
+            item.geometry = footprint
+            item.bbox = list(shape(item.geometry).bounds)
 
             for key, value in item.assets.items():
                 if key == "map":

--- a/datasets/esa-worldcover/esa_worldcover.py
+++ b/datasets/esa-worldcover/esa_worldcover.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List, Union
@@ -9,6 +10,13 @@ from pctasks.core.models.task import WaitTaskResult
 from pctasks.core.storage import StorageFactory
 from pctasks.dataset.collection import Collection
 
+handler = logging.StreamHandler()
+handler.setFormatter(logging.Formatter("[%(levelname)s]:%(asctime)s: %(message)s"))
+handler.setLevel(logging.INFO)
+logger = logging.getLogger(__name__)
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
 
 class ESAWorldCoverCollection(Collection):
     @classmethod
@@ -16,20 +24,31 @@ class ESAWorldCoverCollection(Collection):
         cls, asset_uri: str, storage_factory: StorageFactory
     ) -> Union[List[pystac.Item], WaitTaskResult]:
         with TemporaryDirectory() as tmp_dir:
+            logger.info(f"asset uri = {asset_uri}")
             storage, map_path = storage_factory.get_storage_for_file(asset_uri)
-            tmp_map_path = str(Path(tmp_dir, Path(map_path).name))
-            inputquality_path = map_path.replace("_Map.tif", "_InputQuality.tif")
-            tmp_inputquality_path = tmp_map_path.replace(
-                "_Map.tif", "_InputQuality.tif"
-            )
+            logger.info(f"map path = {map_path}")
+            map_name = Path(map_path).name
+            tmp_map_path = str(Path(tmp_dir, map_name))
+
+            quality_name = map_name.replace("_Map.tif", "_InputQuality.tif")
+            quality_path = str(Path(map_path).parent.parent / "input_quality" / quality_name)
+            logger.info(f"quality path = {quality_path}")
+            tmp_quality_path = str(Path(tmp_dir, quality_name))
 
             storage.download_file(map_path, tmp_map_path)
-            storage.download_file(inputquality_path, tmp_inputquality_path)
+            storage.download_file(quality_path, tmp_quality_path)
 
-            item = create_item(map_href=tmp_map_path, include_quality_asset=True)
+            item = create_item(
+                map_href=tmp_map_path, include_quality_asset=True, raster_footprint=True
+            )
 
             for key, value in item.assets.items():
-                asset_path = str(Path(map_path).parent / Path(value.href).name)
+                if key == "map":
+                    asset_path = map_path
+                elif key == "input_quality":
+                    asset_path = quality_path
+                else:
+                    raise ValueError(f"Unexpected Item asset key '{key}'")
                 item.assets[key].href = storage.get_url(asset_path)
 
         return [item]

--- a/datasets/esa-worldcover/esa_worldcover.py
+++ b/datasets/esa-worldcover/esa_worldcover.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import List, Union
+
+import pystac
+from stactools.esa_worldcover.stac import create_item
+
+from pctasks.core.models.task import WaitTaskResult
+from pctasks.core.storage import StorageFactory
+from pctasks.dataset.collection import Collection
+
+
+class ESAWorldCoverCollection(Collection):
+    @classmethod
+    def create_item(
+        cls, asset_uri: str, storage_factory: StorageFactory
+    ) -> Union[List[pystac.Item], WaitTaskResult]:
+        with TemporaryDirectory() as tmp_dir:
+            storage, map_path = storage_factory.get_storage_for_file(asset_uri)
+            tmp_map_path = str(Path(tmp_dir, Path(map_path).name))
+            inputquality_path = map_path.replace("_Map.tif", "_InputQuality.tif")
+            tmp_inputquality_path = tmp_map_path.replace(
+                "_Map.tif", "_InputQuality.tif"
+            )
+
+            storage.download_file(map_path, tmp_map_path)
+            storage.download_file(inputquality_path, tmp_inputquality_path)
+
+            item = create_item(map_href=tmp_map_path, include_quality_asset=True)
+
+            for key, value in item.assets.items():
+                asset_path = str(Path(map_path).parent / Path(value.href).name)
+                item.assets[key].href = storage.get_url(asset_path)
+
+        return [item]

--- a/datasets/esa-worldcover/esa_worldcover.py
+++ b/datasets/esa-worldcover/esa_worldcover.py
@@ -1,16 +1,9 @@
 import logging
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import List, Optional, Union
+from typing import List, Union
 
-import numpy as np
-import numpy.typing as npt
 import pystac
-import rasterio
-from shapely.geometry import shape
-from shapely.geometry.multipolygon import MultiPolygon
-from shapely.geometry.polygon import Polygon
-from stactools.core.utils.raster_footprint import RasterFootprint
 from stactools.esa_worldcover.stac import create_item
 
 from pctasks.core.models.task import WaitTaskResult
@@ -25,46 +18,13 @@ logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
 
-# This subclass is a workaround for node out-of-memory failures when computing
-# the data mask (the worldcover tiles are large: 36,000x36,000 pixels). We
-# bypass the mask creation and use the mask offered by rasterio. Since rasterio
-# masks use a valid data value of 255 rather than 1, we also override the
-# `data_extent` method. We do not convert the rasterio mask valid data value of
-# 255 to 1, as the conversion logic (np.where()) is the same as that which
-# causes the out-of-memory failure.
-#
-# This subclass may eventually be pushed to the stactools package.
-class RioMaskRasterFootprint(RasterFootprint):
-    def data_mask(self) -> npt.NDArray[np.uint8]:
-        # we are passing rasterio masks as the data array
-        return self.data_array
-
-    def data_extent(self, mask: npt.NDArray[np.uint8]) -> Optional[Polygon]:
-        data_polygons = [
-            shape(polygon_dict)
-            for polygon_dict, region_value in rasterio.features.shapes(
-                mask, transform=self.transform
-            )
-            if region_value == 255  # rasterio masks use 255 (not 1)
-        ]
-        if not data_polygons:
-            return None
-        elif len(data_polygons) == 1:
-            polygon = data_polygons[0]
-        else:
-            polygon = MultiPolygon(data_polygons).convex_hull
-        return polygon
-
-
 class ESAWorldCoverCollection(Collection):
     @classmethod
     def create_item(
         cls, asset_uri: str, storage_factory: StorageFactory
     ) -> Union[List[pystac.Item], WaitTaskResult]:
         with TemporaryDirectory() as tmp_dir:
-            logger.info(f"asset uri = {asset_uri}")
             storage, map_path = storage_factory.get_storage_for_file(asset_uri)
-            logger.info(f"map path = {map_path}")
             map_name = Path(map_path).name
             tmp_map_path = str(Path(tmp_dir, map_name))
 
@@ -72,28 +32,16 @@ class ESAWorldCoverCollection(Collection):
             quality_path = str(
                 Path(map_path).parent.parent / "input_quality" / quality_name
             )
-            logger.info(f"quality path = {quality_path}")
             tmp_quality_path = str(Path(tmp_dir, quality_name))
 
             storage.download_file(map_path, tmp_map_path)
             storage.download_file(quality_path, tmp_quality_path)
 
-            item = create_item(map_href=tmp_map_path, include_quality_asset=True)
+            item = create_item(
+                map_href=tmp_map_path, include_quality_asset=True, raster_footprint=True
+            )
 
-            with rasterio.open(tmp_map_path) as src:
-                assert src.nodata == 0
-                footprint = RioMaskRasterFootprint(
-                    data_array=src.read_masks(1),
-                    crs=src.crs,
-                    transform=src.transform,
-                    densification_distance=0.001,  # roughly 100 meters (10 pixels)
-                    simplify_tolerance=0.0001,  # roughly 10 meters (1 pixel)
-                    no_data=src.nodata,
-                ).footprint()
-            item.geometry = footprint
-            item.bbox = list(shape(item.geometry).bounds)
-
-            for key, value in item.assets.items():
+            for key in item.assets:
                 if key == "map":
                     asset_path = map_path
                 elif key == "input_quality":

--- a/datasets/esa-worldcover/requirements.txt
+++ b/datasets/esa-worldcover/requirements.txt
@@ -1,0 +1,1 @@
+git+https://github.com/stactools-packages/esa-worldcover.git@8b8f8a0d26366f47d8443867c4a8134d6bc21a4a

--- a/datasets/esa-worldcover/requirements.txt
+++ b/datasets/esa-worldcover/requirements.txt
@@ -1,1 +1,1 @@
-stactools-esa-worldcover == 0.2.0
+git+https://github.com/stactools-packages/esa-worldcover.git@164fcfea77954c87eb73d465d8da4bee00e1840c

--- a/datasets/esa-worldcover/requirements.txt
+++ b/datasets/esa-worldcover/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/stactools-packages/esa-worldcover.git@8b8f8a0d26366f47d8443867c4a8134d6bc21a4a
+stactools-esa-worldcover == 0.2.0

--- a/datasets/esa-worldcover/workflows/esa-worldcover-process-items-2020.yaml
+++ b/datasets/esa-worldcover/workflows/esa-worldcover-process-items-2020.yaml
@@ -1,0 +1,97 @@
+name: Process items for esa-worldcover
+tokens: {}
+args:
+- registry
+jobs:
+  create-splits:
+    id: create-splits
+    tasks:
+    - id: create-splits
+      image: ${{ args.registry }}/pctasks-esa-worldcover:latest
+      code:
+        src: datasets/esa-worldcover/esa_worldcover.py
+      task: esa_worldcover:ESAWorldCoverCollection.create_splits_task
+      args:
+        inputs:
+        - uri: blob://ai4edataeuwest/esa-worldcover/
+          chunk_options:
+            chunk_length: 200
+            name_starts_with: v100/2020/map
+            extensions:
+            - .tif
+            limit: 3000
+            list_folders: false
+            chunk_file_name: uris-list
+            chunk_extension: .csv
+        options: {}
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+  create-chunks:
+    id: create-chunks
+    tasks:
+    - id: create-chunks
+      image: ${{ args.registry }}/pctasks-esa-worldcover:latest
+      code:
+        src: datasets/esa-worldcover/esa_worldcover.py
+      task: pctasks.dataset.chunks.task:create_chunks_task
+      args:
+        src_uri: ${{ item.uri }}
+        dst_uri: blob://ai4edataeuwest/esa-worldcover-etl-data/pctasks/2020-all/assets
+        options: ${{ item.chunk_options }}
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+    foreach:
+      items: ${{ jobs.create-splits.tasks.create-splits.output.splits }}
+      flatten: true
+    needs: create-splits
+  process-chunk:
+    id: process-chunk
+    tasks:
+    - id: create-items
+      image: ${{ args.registry }}/pctasks-esa-worldcover:latest
+      code:
+        src: datasets/esa-worldcover/esa_worldcover.py
+      task: esa_worldcover:ESAWorldCoverCollection.create_items_task
+      args:
+        asset_chunk_info:
+          uri: ${{ item.uri }}
+          chunk_id: ${{ item.chunk_id }}
+        item_chunkset_uri: blob://ai4edataeuwest/esa-worldcover-etl-data/pctasks/2020-all/items
+        collection_id: esa-worldcover
+        options:
+          skip_validation: false
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+    - id: ingest-items
+      image_key: ingest
+      task: pctasks.ingest_task.task:ingest_task
+      args:
+        content:
+          type: Ndjson
+          uris:
+          - ${{tasks.create-items.output.ndjson_uri}}
+        options:
+          insert_group_size: 5000
+          insert_only: false
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+    foreach:
+      items: ${{ jobs.create-chunks.tasks.create-chunks.output.chunks }}
+      flatten: true
+    needs: create-chunks
+schema_version: 1.0.0
+id: esa-worldcover-process-items
+dataset: esa-worldcover
+

--- a/datasets/esa-worldcover/workflows/esa-worldcover-process-items-2021.yaml
+++ b/datasets/esa-worldcover/workflows/esa-worldcover-process-items-2021.yaml
@@ -1,0 +1,97 @@
+name: Process items for esa-worldcover
+tokens: {}
+args:
+- registry
+jobs:
+  create-splits:
+    id: create-splits
+    tasks:
+    - id: create-splits
+      image: ${{ args.registry }}/pctasks-esa-worldcover:latest
+      code:
+        src: datasets/esa-worldcover/esa_worldcover.py
+      task: esa_worldcover:ESAWorldCoverCollection.create_splits_task
+      args:
+        inputs:
+        - uri: blob://ai4edataeuwest/esa-worldcover/
+          chunk_options:
+            chunk_length: 200
+            name_starts_with: v200/2021/map
+            extensions:
+            - .tif
+            limit: 3000
+            list_folders: false
+            chunk_file_name: uris-list
+            chunk_extension: .csv
+        options: {}
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+  create-chunks:
+    id: create-chunks
+    tasks:
+    - id: create-chunks
+      image: ${{ args.registry }}/pctasks-esa-worldcover:latest
+      code:
+        src: datasets/esa-worldcover/esa_worldcover.py
+      task: pctasks.dataset.chunks.task:create_chunks_task
+      args:
+        src_uri: ${{ item.uri }}
+        dst_uri: blob://ai4edataeuwest/esa-worldcover-etl-data/pctasks/2021-all/assets
+        options: ${{ item.chunk_options }}
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+    foreach:
+      items: ${{ jobs.create-splits.tasks.create-splits.output.splits }}
+      flatten: true
+    needs: create-splits
+  process-chunk:
+    id: process-chunk
+    tasks:
+    - id: create-items
+      image: ${{ args.registry }}/pctasks-esa-worldcover:latest
+      code:
+        src: datasets/esa-worldcover/esa_worldcover.py
+      task: esa_worldcover:ESAWorldCoverCollection.create_items_task
+      args:
+        asset_chunk_info:
+          uri: ${{ item.uri }}
+          chunk_id: ${{ item.chunk_id }}
+        item_chunkset_uri: blob://ai4edataeuwest/esa-worldcover-etl-data/pctasks/2021-all/items
+        collection_id: esa-worldcover
+        options:
+          skip_validation: false
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+    - id: ingest-items
+      image_key: ingest
+      task: pctasks.ingest_task.task:ingest_task
+      args:
+        content:
+          type: Ndjson
+          uris:
+          - ${{tasks.create-items.output.ndjson_uri}}
+        options:
+          insert_group_size: 5000
+          insert_only: false
+      environment:
+        AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+        AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+        AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+      schema_version: 1.0.0
+    foreach:
+      items: ${{ jobs.create-chunks.tasks.create-chunks.output.chunks }}
+      flatten: true
+    needs: create-chunks
+schema_version: 1.0.0
+id: esa-worldcover-process-items
+dataset: esa-worldcover
+


### PR DESCRIPTION
## Description

Adds the ESA WorldCover dataset, including version 1 (2020 data) and version 2 (2021 data). Note that 2020 STAC already exists in the PC via the old ETL pipeline. 
- STAC Collection and description updated to include the new 2021 data
- Uses a raster footprint for the Item geometries (2020 Items in production use the tile boundary)
- Adds the grid extension to the STAC Items (2020 Items in production do not have this)
- Adds the "InputQuality" asset (2020 Items in production do not have this)

_It is expected that the existing 2020 Items will be reprocessed to use a raster footprint geometry, add the grid extension, and add the InputQuality asset._

PC Test Links:
- [STAC Collection](https://pct-apis-staging.westeurope.cloudapp.azure.com/stac/collections/esa-worldcover)
- [Data Catalog dataset page](https://planetarycomputer-test.microsoft.com/dataset/esa-worldcover)

2021 Data Explorer Screenshot:
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/7013017/227065411-81a9ca68-05ce-43e9-b2a0-2e5233f45808.png">

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ingested all 2020 and 2021 data into PC Test.

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)