### PR TITLE
[core]: Add helper to rewrite blob storage urls

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -20,6 +20,7 @@ Helper functions and classes for dealing with local or remote file systems.
    pctasks.core.storage.StorageFactory
    pctasks.core.storage.blob.BlobUri
    pctasks.core.storage.blob.BlobStorage
+   pctasks.core.storage.blob.maybe_rewrite_blob_storage_url
 ```
 
 ## `pctasks.task`

--- a/pctasks/core/tests/storage/test_blob.py
+++ b/pctasks/core/tests/storage/test_blob.py
@@ -2,6 +2,9 @@ import os
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+import pytest
+
+from pctasks.core.storage.blob import maybe_rewrite_blob_storage_url
 from pctasks.dev.blob import temp_azurite_blob_storage
 from pctasks.dev.constants import AZURITE_ACCOUNT_NAME, TEST_DATA_CONTAINER
 
@@ -100,3 +103,26 @@ def test_blob_download_timeout():
                     storage_stream_downloader._request_options.pop("timeout", None)
                     is None
                 )
+
+
+@pytest.mark.parametrize(
+    "url, expected",
+    [
+        (
+            "https://example.blob.core.windows.net/container/path/file.txt",
+            "blob://example/container/path/file.txt",
+        ),
+        (
+            "https://azurite:10000/devstoreaccount1/container/path/file.txt",
+            "blob://devstoreaccount1/container/path/file.txt",
+        ),
+        (
+            "https://localhost:10000/devstoreaccount1/container/path/file.txt",
+            "blob://devstoreaccount1/container/path/file.txt",
+        ),
+        ("path/file.txt", "path/file.txt"),
+    ],
+)
+def test_maybe_rewrite_blob_storage_url(url, expected):
+    result = maybe_rewrite_blob_storage_url(url)
+    assert result == expected


### PR DESCRIPTION
## Description

In the low-latency branch, EventGrid gives us urls like `https://<account>.blob.core.windows.net/<container>/<path>`. The create items function expect `blob://<account>/<container>/<path>` URLs. This function implements that.

I didn't *see* this implemented anywhere, but I might have missed it.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)