### PR TITLE
[wip]: Helper to create a collection from a summary object.

### DIFF
--- a/pctasks/core/pctasks/core/utils/dask_summary.py
+++ b/pctasks/core/pctasks/core/utils/dask_summary.py
@@ -1,0 +1,94 @@
+import contextlib
+import logging
+import json
+import typing
+import random
+import functools
+
+import azure.storage.blob
+import dask
+import dask.bag
+import dask_kubernetes.operator
+
+
+import pctasks.core.utils.summary
+
+
+logger = logging.getLogger(__name__)
+
+
+@dask.delayed
+def list_prefixes(prefix: str, depth: int, storage_options: dict[str, typing.Any]):
+    prefix = prefix.rstrip("/") + "/"
+    d = prefix.count("/")
+    cc = azure.storage.blob.ContainerClient(**storage_options)
+    blob_names = []
+    with cc:
+        if d < depth:
+            prefixes = [x.name for x in cc.walk_blobs(prefix)]
+            xs = [
+                list_prefixes(x, depth, storage_options) for x in prefixes
+            ]
+            for x in xs:
+                blob_names.extend(x.compute())
+        elif d == depth:
+            return [prefix]
+    return blob_names
+
+
+@dask.delayed
+def read_prefix(x: str, storage_options: dict[str, typing.Any], fraction=1.0) -> typing.List[bytes]:
+    cc = azure.storage.blob.ContainerClient(**storage_options)
+    assert 0 <= fraction <= 1.0
+
+    items: typing.List[bytes] = []
+    blobs = list(cc.list_blobs(x))
+    blobs = random.sample(blobs, int(len(blobs) * fraction))
+    
+    with cc:
+        for blob in blobs:
+            content = cc.get_blob_client(blob).download_blob().readall()
+            items.append(content)
+
+    return items
+
+
+def summarize_partition(items: typing.List[typing.Dict]) -> pctasks.core.utils.summary.ObjectSummary:
+    first, *rest = items
+    result = pctasks.core.utils.summary.ObjectSummary.summarize_dict(first)
+    for item in rest:
+        result = result.merge(pctasks.core.utils.summary.ObjectSummary.summarize_dict(item))
+    return result
+
+
+aggregate = lambda x: functools.reduce(lambda a, b: a.merge(b), x)
+
+
+@contextlib.contextmanager
+def get_compute():
+    with dask_kubernetes.operator.KubeCluster(
+        namespace="dask",
+        image="pccomponents.azurecr.io/pctasks-dask:2023.4.13.0",
+        resources={
+            "requests": {"memory": "7Gi", "cpu": "0.9"},
+            "limit": {"memory": "8Gi", "cpu": "1"}
+        },
+    ) as cluster:
+        with cluster.get_client() as client:
+            cluster.scale(8)
+            print(client.dashboard_link)
+            yield client
+
+
+def summarize(prefix, depth, storage_options):
+    """
+    prefix="OLCI/OL_2_LFR___/", depth=5
+    """
+    with get_compute():
+        logger.info("Listing prefixes. prefix=%s", prefix)
+        prefixes = list_prefixes(prefix, depth, storage_options).compute()
+        logger.info("prefix_count=%d", len(prefixes))
+        bag = dask.bag.from_delayed([read_prefix(x, storage_options) for x in prefixes]).map(json.loads)
+        summary = bag.reduction(summarize, aggregate).compute()
+
+    return summary

--- a/pctasks/core/pctasks/core/utils/dask_summary.py
+++ b/pctasks/core/pctasks/core/utils/dask_summary.py
@@ -1,18 +1,16 @@
 import contextlib
-import logging
-import json
-import typing
-import random
 import functools
+import json
+import logging
+import random
+import typing
 
 import azure.storage.blob
 import dask
 import dask.bag
 import dask_kubernetes.operator
 
-
 import pctasks.core.utils.summary
-
 
 logger = logging.getLogger(__name__)
 
@@ -26,9 +24,7 @@ def list_prefixes(prefix: str, depth: int, storage_options: dict[str, typing.Any
     with cc:
         if d < depth:
             prefixes = [x.name for x in cc.walk_blobs(prefix)]
-            xs = [
-                list_prefixes(x, depth, storage_options) for x in prefixes
-            ]
+            xs = [list_prefixes(x, depth, storage_options) for x in prefixes]
             for x in xs:
                 blob_names.extend(x.compute())
         elif d == depth:
@@ -37,14 +33,16 @@ def list_prefixes(prefix: str, depth: int, storage_options: dict[str, typing.Any
 
 
 @dask.delayed
-def read_prefix(x: str, storage_options: dict[str, typing.Any], fraction=1.0) -> typing.List[bytes]:
+def read_prefix(
+    x: str, storage_options: dict[str, typing.Any], fraction=1.0
+) -> typing.List[bytes]:
     cc = azure.storage.blob.ContainerClient(**storage_options)
     assert 0 <= fraction <= 1.0
 
     items: typing.List[bytes] = []
     blobs = list(cc.list_blobs(x))
     blobs = random.sample(blobs, int(len(blobs) * fraction))
-    
+
     with cc:
         for blob in blobs:
             content = cc.get_blob_client(blob).download_blob().readall()
@@ -53,11 +51,15 @@ def read_prefix(x: str, storage_options: dict[str, typing.Any], fraction=1.0) ->
     return items
 
 
-def summarize_partition(items: typing.List[typing.Dict]) -> pctasks.core.utils.summary.ObjectSummary:
+def summarize_partition(
+    items: typing.List[typing.Dict],
+) -> pctasks.core.utils.summary.ObjectSummary:
     first, *rest = items
     result = pctasks.core.utils.summary.ObjectSummary.summarize_dict(first)
     for item in rest:
-        result = result.merge(pctasks.core.utils.summary.ObjectSummary.summarize_dict(item))
+        result = result.merge(
+            pctasks.core.utils.summary.ObjectSummary.summarize_dict(item)
+        )
     return result
 
 
@@ -71,7 +73,7 @@ def get_compute():
         image="pccomponents.azurecr.io/pctasks-dask:2023.4.13.0",
         resources={
             "requests": {"memory": "7Gi", "cpu": "0.9"},
-            "limit": {"memory": "8Gi", "cpu": "1"}
+            "limit": {"memory": "8Gi", "cpu": "1"},
         },
     ) as cluster:
         with cluster.get_client() as client:
@@ -88,7 +90,9 @@ def summarize(prefix, depth, storage_options):
         logger.info("Listing prefixes. prefix=%s", prefix)
         prefixes = list_prefixes(prefix, depth, storage_options).compute()
         logger.info("prefix_count=%d", len(prefixes))
-        bag = dask.bag.from_delayed([read_prefix(x, storage_options) for x in prefixes]).map(json.loads)
+        bag = dask.bag.from_delayed(
+            [read_prefix(x, storage_options) for x in prefixes]
+        ).map(json.loads)
         summary = bag.reduction(summarize, aggregate).compute()
 
     return summary

--- a/pctasks/core/pctasks/core/utils/summary.py
+++ b/pctasks/core/pctasks/core/utils/summary.py
@@ -893,7 +893,7 @@ def make_collection(
         "stac_version": "1.0.0",
         "id": collection_id,
         "type": "Collection",
-        "description":description,
+        "description": description,
         "links": links or [],
         "title": title,
         "keywords": keywords or [],
@@ -909,7 +909,7 @@ def make_collection(
         summary_value = summary.keys["properties"].summary.keys[key]
         value = None
         # if key == "constellation":
-            # breakpoint()
+        # breakpoint()
         if summary_value.type == "distinct":
             if summary_value.type == "string":
                 value = summary_value.values[0]
@@ -925,31 +925,88 @@ def make_collection(
 
     return collection
 
+
 def make_collection(
     summary: ObjectSummary,
     collection_id: str,
     keywords: list[str] | None = None,
     stac_extensions: list[str] | None = None,
-    extra_fields: dict[str, Any] | None = None,
     title: str | None = None,
     description: str = "{{ collection.description }}",
-    links: list[str] | None = [],
-):
+    links: list[str] | None = None,
+    assets: dict[str, dict] | None = None,
+    extra_summary_exclude: set[str] | None = None,
+    item_assets_exclude: set[str] | None = None,
+    extra_fields: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """
+    Create a STAC collection from an ObjectSummary.
+
+    Parameters
+    ----------
+    summary
+        The summary of the items in the collection, built from analyzing many items
+        and merging the results.
+    collection_id
+        The ID of the STAC collection.
+    keywords
+        An optional list of keywords to include in the collection.
+    stac_extensions
+        An optional list of STAC extensions to include in the collection.
+    title
+        An optional title for the collection.
+    description
+        An optional description for the collection.  
+    links
+        Optional list of links to include in the collection.
+    assets
+        Optional mapping of collection-level assets for the collection.
+    extra_summary_exclude
+        Additional keys to exclude from ``summaries``. By default, all
+        keys in the ``properties`` will be included *except*
+
+        - datetime
+        - start_datetime
+        - end_datetime
+
+    item_assets_exclude
+        A set of keys to exclude from the automatic ``item_assets``.
+        For example, passing ``item_assets_exclude={'eo:bands'}`` will
+        prevent the ``eo:bands`` property from being included in
+        the ``item_assets`` for any asset that does have ``eo:bands``.
+
+    extra_fields
+        A mapping of additional fields to include on the collection.
+
+    Returns
+    -------
+    dict
+        The dictionary containing the STAC collection.
+
+    Notes
+    -----
+    This returns ...
+    """
+    # TODO: auto-include item_assets when finding some
+    # TODO: flag to enable / disable item_assets, summaries
+    # TODO: Cusom merge for `geometry` type to get the union (for extent)
     asset_summary = summary.keys["assets"].summary
 
     item_assets = {}
+    item_assets_exclude = item_assets_exclude or set()
 
     for k, asset_summary in summary.keys["assets"].summary.keys.items():
         # assuming we'll move these from description to title
         # TODO: assert one
-        item_assets[k] = {
-            # "title": asset_summary.summary.keys["description"].values[0].value,
-            "type": asset_summary.summary.keys["type"].values[0].value,
-            "roles": asset_summary.summary.keys["roles"].values[0].value,
-        }
+        item_assets[k] = {}
+
+        for field, value in asset_summary.summary.keys.items():
+            if value.type == "distinct" and field not in item_assets_exclude:
+                item_assets[k][field] = (
+                    asset_summary.summary.keys[field].values[0].value
+                )
 
         if eo_bands := asset_summary.summary.keys.get("eo:bands"):
-            print("x!")
             item_assets[k]["eo:bands"] = [
                 {
                     "name": band.keys["name"].values[0].value,
@@ -964,29 +1021,46 @@ def make_collection(
         "stac_version": "1.0.0",
         "id": collection_id,
         "type": "Collection",
-        "description":description,
+        "description": description,
         "links": links or [],
-        "title": title,
         "keywords": keywords or [],
         "stac_extensions": stac_extensions or [],
         "summaries": {},
         "item_assets": item_assets,
     }
 
-    summary_keys = ["constellation", "platform", "instruments"]
+    optional = {"title": title, "assets": assets}
+    for k, v in optional.items():
+        if v is not None:
+            collection[k] = v
 
-    for key in summary_keys:
-        print(key)
-        summary_value = summary.keys["properties"].summary.keys[key]
+    exclude = {
+        "start_datetime",
+        "end_datetime",
+        "datetime",
+    }
+
+    exclude |= extra_summary_exclude or set()
+
+    properties = summary.keys["properties"].summary
+
+    for key, summary_value in properties.keys.items():
+        if key in exclude:
+            continue
         value = None
         # if key == "constellation":
-            # breakpoint()
+        # breakpoint()
         if summary_value.type == "distinct":
             if summary_value.type == "string":
                 value = summary_value.values[0]
                 value = [value.value]
             else:
                 value = [value.value for value in summary_value.values]
+        elif summary_value.type in ("int-range", "float-range"):
+            value = {
+                "minimum": summary_value.min,
+                "maximum": summary_value.max,
+            }
         else:
             value = [x.value for x in summary_value.values]
 

--- a/pctasks/core/pctasks/core/utils/summary.py
+++ b/pctasks/core/pctasks/core/utils/summary.py
@@ -16,7 +16,6 @@ from pctasks.core.utils import map_opt
 
 
 class SummarySettings(BaseModel):
-
     max_distinct_values = 4
     """The max number of distinct values to collect in a distinct value summary.
 
@@ -853,3 +852,146 @@ class ObjectSummary(BaseModel):
 ObjectListSummary.update_forward_refs()
 ObjectPropertySummary.update_forward_refs()
 MixedObjectListSummary.update_forward_refs()
+
+
+def make_collection(
+    summary: ObjectSummary,
+    collection_id: str,
+    keywords: list[str] | None = None,
+    stac_extensions: list[str] | None = None,
+    extra_fields: dict[str, Any] | None = None,
+    title: str | None = None,
+    description: str = "{{ collection.description }}",
+    links: list[str] | None = [],
+):
+    asset_summary = summary.keys["assets"].summary
+
+    item_assets = {}
+
+    for k, asset_summary in summary.keys["assets"].summary.keys.items():
+        # assuming we'll move these from description to title
+        # TODO: assert one
+        item_assets[k] = {
+            # "title": asset_summary.summary.keys["description"].values[0].value,
+            "type": asset_summary.summary.keys["type"].values[0].value,
+            "roles": asset_summary.summary.keys["roles"].values[0].value,
+        }
+
+        if eo_bands := asset_summary.summary.keys.get("eo:bands"):
+            print("x!")
+            item_assets[k]["eo:bands"] = [
+                {
+                    "name": band.keys["name"].values[0].value,
+                    "description": band.keys["description"].values[0].value,
+                    "center_wavelength": band.keys["center_wavelength"].values[0].value,
+                    "band_width": band.keys["band_width"].values[0].value,
+                }
+                for band in eo_bands.values
+            ]
+
+    collection = {
+        "stac_version": "1.0.0",
+        "id": collection_id,
+        "type": "Collection",
+        "description":description,
+        "links": links or [],
+        "title": title,
+        "keywords": keywords or [],
+        "stac_extensions": stac_extensions or [],
+        "summaries": {},
+        "item_assets": item_assets,
+    }
+
+    summary_keys = ["constellation", "platform", "instruments"]
+
+    for key in summary_keys:
+        print(key)
+        summary_value = summary.keys["properties"].summary.keys[key]
+        value = None
+        # if key == "constellation":
+            # breakpoint()
+        if summary_value.type == "distinct":
+            if summary_value.type == "string":
+                value = summary_value.values[0]
+                value = [value.value]
+            else:
+                value = [value.value for value in summary_value.values]
+        else:
+            value = [x.value for x in summary_value.values]
+
+        collection["summaries"][key] = value
+
+    collection.update(extra_fields or {})
+
+    return collection
+
+def make_collection(
+    summary: ObjectSummary,
+    collection_id: str,
+    keywords: list[str] | None = None,
+    stac_extensions: list[str] | None = None,
+    extra_fields: dict[str, Any] | None = None,
+    title: str | None = None,
+    description: str = "{{ collection.description }}",
+    links: list[str] | None = [],
+):
+    asset_summary = summary.keys["assets"].summary
+
+    item_assets = {}
+
+    for k, asset_summary in summary.keys["assets"].summary.keys.items():
+        # assuming we'll move these from description to title
+        # TODO: assert one
+        item_assets[k] = {
+            # "title": asset_summary.summary.keys["description"].values[0].value,
+            "type": asset_summary.summary.keys["type"].values[0].value,
+            "roles": asset_summary.summary.keys["roles"].values[0].value,
+        }
+
+        if eo_bands := asset_summary.summary.keys.get("eo:bands"):
+            print("x!")
+            item_assets[k]["eo:bands"] = [
+                {
+                    "name": band.keys["name"].values[0].value,
+                    "description": band.keys["description"].values[0].value,
+                    "center_wavelength": band.keys["center_wavelength"].values[0].value,
+                    "band_width": band.keys["band_width"].values[0].value,
+                }
+                for band in eo_bands.values
+            ]
+
+    collection = {
+        "stac_version": "1.0.0",
+        "id": collection_id,
+        "type": "Collection",
+        "description":description,
+        "links": links or [],
+        "title": title,
+        "keywords": keywords or [],
+        "stac_extensions": stac_extensions or [],
+        "summaries": {},
+        "item_assets": item_assets,
+    }
+
+    summary_keys = ["constellation", "platform", "instruments"]
+
+    for key in summary_keys:
+        print(key)
+        summary_value = summary.keys["properties"].summary.keys[key]
+        value = None
+        # if key == "constellation":
+            # breakpoint()
+        if summary_value.type == "distinct":
+            if summary_value.type == "string":
+                value = summary_value.values[0]
+                value = [value.value]
+            else:
+                value = [value.value for value in summary_value.values]
+        else:
+            value = [x.value for x in summary_value.values]
+
+        collection["summaries"][key] = value
+
+    collection.update(extra_fields or {})
+
+    return collection

--- a/pctasks/core/tests/data-files/summaries/sentinel-3-olci-lfr-l2-netcdf.json
+++ b/pctasks/core/tests/data-files/summaries/sentinel-3-olci-lfr-l2-netcdf.json
@@ -1,0 +1,4928 @@
+{
+    "count": 263463,
+    "keys": {
+        "type": {
+            "type": "distinct",
+            "count_with": 263463,
+            "count_without": 0,
+            "values": [
+                {
+                    "type": "string",
+                    "count": 263463,
+                    "value": "Feature"
+                }
+            ]
+        },
+        "stac_version": {
+            "type": "distinct",
+            "count_with": 263463,
+            "count_without": 0,
+            "values": [
+                {
+                    "type": "string",
+                    "count": 263463,
+                    "value": "1.0.0"
+                }
+            ]
+        },
+        "id": {
+            "type": "mixed-value",
+            "count_with": 263463,
+            "count_without": 0,
+            "data_types": [
+                "string"
+            ],
+            "sample": [
+                {
+                    "type": "string",
+                    "count": 1,
+                    "value": "S3A_OL_2_LFR_20160425T164019_20160425T164319_0179_003_240_1620"
+                },
+                {
+                    "type": "string",
+                    "count": 1,
+                    "value": "S3A_OL_2_LFR_20160425T145619_20160425T145919_0179_003_239_1440"
+                },
+                {
+                    "type": "string",
+                    "count": 1,
+                    "value": "S3A_OL_2_LFR_20160425T233915_20160425T234215_0179_003_244_2520"
+                },
+                {
+                    "type": "string",
+                    "count": 1,
+                    "value": "S3A_OL_2_LFR_20160425T213907_20160425T214016_0069_003_243_1260"
+                }
+            ]
+        },
+        "properties": {
+            "type": "object",
+            "count_with": 263463,
+            "count_without": 0,
+            "summary": {
+                "count": 263463,
+                "keys": {
+                    "sat:platform_international_designator": {
+                        "type": "distinct",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "values": [
+                            {
+                                "type": "string",
+                                "count": 153325,
+                                "value": "2016-011A"
+                            },
+                            {
+                                "type": "string",
+                                "count": 110138,
+                                "value": "2018-039A"
+                            }
+                        ]
+                    },
+                    "sat:orbit_state": {
+                        "type": "distinct",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "values": [
+                            {
+                                "type": "string",
+                                "count": 245160,
+                                "value": "descending"
+                            },
+                            {
+                                "type": "string",
+                                "count": 18303,
+                                "value": "ascending"
+                            }
+                        ]
+                    },
+                    "sat:absolute_orbit": {
+                        "type": "int-range",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "min": 285,
+                        "max": 37257
+                    },
+                    "sat:relative_orbit": {
+                        "type": "int-range",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "min": 1,
+                        "max": 442
+                    },
+                    "eo:cloud_cover": {
+                        "type": "float-range",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "min": 0.0,
+                        "max": 99.0
+                    },
+                    "start_datetime": {
+                        "type": "mixed-value",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "data_types": [
+                            "string"
+                        ],
+                        "sample": [
+                            {
+                                "type": "string",
+                                "count": 1,
+                                "value": "2016-04-25 16:40:18.562600+00:00"
+                            },
+                            {
+                                "type": "string",
+                                "count": 1,
+                                "value": "2016-04-25 14:56:19.341730+00:00"
+                            },
+                            {
+                                "type": "string",
+                                "count": 1,
+                                "value": "2016-04-25 23:39:15.446073+00:00"
+                            },
+                            {
+                                "type": "string",
+                                "count": 1,
+                                "value": "2016-04-25 21:39:06.691908+00:00"
+                            }
+                        ]
+                    },
+                    "end_datetime": {
+                        "type": "mixed-value",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "data_types": [
+                            "string"
+                        ],
+                        "sample": [
+                            {
+                                "type": "string",
+                                "count": 1,
+                                "value": "2016-04-25 16:43:18.562600+00:00"
+                            },
+                            {
+                                "type": "string",
+                                "count": 1,
+                                "value": "2016-04-25 14:59:19.341730+00:00"
+                            },
+                            {
+                                "type": "string",
+                                "count": 1,
+                                "value": "2016-04-25 23:42:15.446073+00:00"
+                            },
+                            {
+                                "type": "string",
+                                "count": 1,
+                                "value": "2016-04-25 21:40:16.225192+00:00"
+                            }
+                        ]
+                    },
+                    "instruments": {
+                        "type": "distinct",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "values": [
+                            {
+                                "type": "list",
+                                "count": 263463,
+                                "value": [
+                                    "OLCI"
+                                ]
+                            }
+                        ]
+                    },
+                    "s3:mode": {
+                        "type": "distinct",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "values": [
+                            {
+                                "type": "string",
+                                "count": 263463,
+                                "value": "EO"
+                            }
+                        ]
+                    },
+                    "s3:productType": {
+                        "type": "distinct",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "values": [
+                            {
+                                "type": "string",
+                                "count": 263463,
+                                "value": "OL_2_LFR___"
+                            }
+                        ]
+                    },
+                    "s3:gsd": {
+                        "type": "distinct",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "values": [
+                            {
+                                "type": "numeric-int",
+                                "count": 263463,
+                                "value": 300
+                            }
+                        ]
+                    },
+                    "s3:salineWaterPixels_percentage": {
+                        "type": "float-range",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "min": 0.0,
+                        "max": 94.0
+                    },
+                    "s3:coastalPixels_percentage": {
+                        "type": "float-range",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "min": 0.0,
+                        "max": 0.967052
+                    },
+                    "s3:freshInlandWaterPixels_percentage": {
+                        "type": "float-range",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "min": 0.0,
+                        "max": 21.0
+                    },
+                    "s3:tidalRegionPixels_percentage": {
+                        "type": "float-range",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "min": 0.0,
+                        "max": 15.0
+                    },
+                    "s3:landPixels_percentage": {
+                        "type": "float-range",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "min": 0.0,
+                        "max": 97.0
+                    },
+                    "s3:invalidPixels_percentage": {
+                        "type": "float-range",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "min": 1.0,
+                        "max": 100.0
+                    },
+                    "s3:cosmeticPixels_percentage": {
+                        "type": "float-range",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "min": 0.0,
+                        "max": 49.0
+                    },
+                    "s3:duplicatedPixels_percentage": {
+                        "type": "float-range",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "min": 0.001229,
+                        "max": 25.515308
+                    },
+                    "s3:saturatedPixels_percentage": {
+                        "type": "distinct",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "values": [
+                            {
+                                "type": "numeric-float",
+                                "count": 263463,
+                                "value": 0.0
+                            }
+                        ]
+                    },
+                    "s3:dubiousSamples_percentage": {
+                        "type": "float-range",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "min": 0.0,
+                        "max": 38.0
+                    },
+                    "s3:shape": {
+                        "type": "mixed-value",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "data_types": [
+                            "list"
+                        ],
+                        "sample": [
+                            {
+                                "type": "list",
+                                "count": 10,
+                                "value": [
+                                    4865,
+                                    4091
+                                ]
+                            },
+                            {
+                                "type": "list",
+                                "count": 1,
+                                "value": [
+                                    4865,
+                                    1580
+                                ]
+                            },
+                            {
+                                "type": "list",
+                                "count": 1,
+                                "value": [
+                                    4865,
+                                    1535
+                                ]
+                            },
+                            {
+                                "type": "list",
+                                "count": 1,
+                                "value": [
+                                    4865,
+                                    1532
+                                ]
+                            }
+                        ]
+                    },
+                    "providers": {
+                        "type": "object-list",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "values": [
+                            {
+                                "count": 263463,
+                                "keys": {
+                                    "name": {
+                                        "type": "distinct",
+                                        "count_with": 263463,
+                                        "count_without": 0,
+                                        "values": [
+                                            {
+                                                "type": "string",
+                                                "count": 263463,
+                                                "value": "ESA"
+                                            }
+                                        ]
+                                    },
+                                    "roles": {
+                                        "type": "distinct",
+                                        "count_with": 263463,
+                                        "count_without": 0,
+                                        "values": [
+                                            {
+                                                "type": "list",
+                                                "count": 263463,
+                                                "value": [
+                                                    "producer",
+                                                    "processor",
+                                                    "licensor"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "url": {
+                                        "type": "distinct",
+                                        "count_with": 263463,
+                                        "count_without": 0,
+                                        "values": [
+                                            {
+                                                "type": "string",
+                                                "count": 263463,
+                                                "value": "https://earth.esa.int/web/guest/home"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "key_sets": {
+                                    "type": "distinct",
+                                    "values": [
+                                        {
+                                            "keys": [
+                                                "url",
+                                                "name",
+                                                "roles"
+                                            ],
+                                            "count_with": 263463
+                                        }
+                                    ]
+                                }
+                            },
+                            {
+                                "count": 263463,
+                                "keys": {
+                                    "name": {
+                                        "type": "distinct",
+                                        "count_with": 263463,
+                                        "count_without": 0,
+                                        "values": [
+                                            {
+                                                "type": "string",
+                                                "count": 263463,
+                                                "value": "Microsoft"
+                                            }
+                                        ]
+                                    },
+                                    "roles": {
+                                        "type": "distinct",
+                                        "count_with": 263463,
+                                        "count_without": 0,
+                                        "values": [
+                                            {
+                                                "type": "list",
+                                                "count": 263463,
+                                                "value": [
+                                                    "host",
+                                                    "processor"
+                                                ]
+                                            }
+                                        ]
+                                    },
+                                    "url": {
+                                        "type": "distinct",
+                                        "count_with": 263463,
+                                        "count_without": 0,
+                                        "values": [
+                                            {
+                                                "type": "string",
+                                                "count": 263463,
+                                                "value": "https://planetarycomputer.microsoft.com"
+                                            }
+                                        ]
+                                    }
+                                },
+                                "key_sets": {
+                                    "type": "distinct",
+                                    "values": [
+                                        {
+                                            "keys": [
+                                                "url",
+                                                "name",
+                                                "roles"
+                                            ],
+                                            "count_with": 263463
+                                        }
+                                    ]
+                                }
+                            }
+                        ]
+                    },
+                    "platform": {
+                        "type": "distinct",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "values": [
+                            {
+                                "type": "string",
+                                "count": 153325,
+                                "value": "Sentinel-3A"
+                            },
+                            {
+                                "type": "string",
+                                "count": 110138,
+                                "value": "Sentinel-3B"
+                            }
+                        ]
+                    },
+                    "constellation": {
+                        "type": "distinct",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "values": [
+                            {
+                                "type": "string",
+                                "count": 263463,
+                                "value": "Sentinel-3"
+                            }
+                        ]
+                    },
+                    "datetime": {
+                        "type": "mixed-value",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "data_types": [
+                            "string"
+                        ],
+                        "sample": [
+                            {
+                                "type": "string",
+                                "count": 1,
+                                "value": "2016-04-25T16:41:48.562600Z"
+                            },
+                            {
+                                "type": "string",
+                                "count": 1,
+                                "value": "2016-04-25T14:57:49.341730Z"
+                            },
+                            {
+                                "type": "string",
+                                "count": 1,
+                                "value": "2016-04-25T23:40:45.446073Z"
+                            },
+                            {
+                                "type": "string",
+                                "count": 1,
+                                "value": "2016-04-25T21:39:41.458550Z"
+                            }
+                        ]
+                    }
+                },
+                "key_sets": {
+                    "type": "distinct",
+                    "values": [
+                        {
+                            "keys": [
+                                "s3:dubiousSamples_percentage",
+                                "start_datetime",
+                                "eo:cloud_cover",
+                                "s3:productType",
+                                "s3:freshInlandWaterPixels_percentage",
+                                "providers",
+                                "s3:gsd",
+                                "sat:absolute_orbit",
+                                "sat:platform_international_designator",
+                                "datetime",
+                                "constellation",
+                                "s3:tidalRegionPixels_percentage",
+                                "sat:orbit_state",
+                                "sat:relative_orbit",
+                                "platform",
+                                "s3:landPixels_percentage",
+                                "s3:coastalPixels_percentage",
+                                "instruments",
+                                "s3:mode",
+                                "s3:duplicatedPixels_percentage",
+                                "s3:cosmeticPixels_percentage",
+                                "s3:salineWaterPixels_percentage",
+                                "s3:shape",
+                                "s3:invalidPixels_percentage",
+                                "s3:saturatedPixels_percentage",
+                                "end_datetime"
+                            ],
+                            "count_with": 263463
+                        }
+                    ]
+                }
+            }
+        },
+        "geometry": {
+            "type": "object",
+            "count_with": 263463,
+            "count_without": 0,
+            "summary": {
+                "count": 263463,
+                "keys": {
+                    "type": {
+                        "type": "distinct",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "values": [
+                            {
+                                "type": "string",
+                                "count": 263463,
+                                "value": "Polygon"
+                            }
+                        ]
+                    },
+                    "coordinates": {
+                        "type": "mixed-value",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "data_types": [
+                            "list"
+                        ],
+                        "sample": [
+                            {
+                                "type": "list",
+                                "count": 1,
+                                "value": [
+                                    [
+                                        [
+                                            -102.694,
+                                            73.1954
+                                        ],
+                                        [
+                                            -100.557,
+                                            73.1622
+                                        ],
+                                        [
+                                            -98.4302,
+                                            73.1079
+                                        ],
+                                        [
+                                            -96.3318,
+                                            73.0324
+                                        ],
+                                        [
+                                            -94.2255,
+                                            72.9341
+                                        ],
+                                        [
+                                            -92.1705,
+                                            72.8159
+                                        ],
+                                        [
+                                            -90.1394,
+                                            72.6768
+                                        ],
+                                        [
+                                            -88.1361,
+                                            72.5177
+                                        ],
+                                        [
+                                            -86.1721,
+                                            72.3382
+                                        ],
+                                        [
+                                            -84.2474,
+                                            72.1395
+                                        ],
+                                        [
+                                            -82.365,
+                                            71.926
+                                        ],
+                                        [
+                                            -80.5335,
+                                            71.6915
+                                        ],
+                                        [
+                                            -78.7386,
+                                            71.4415
+                                        ],
+                                        [
+                                            -76.9956,
+                                            71.1721
+                                        ],
+                                        [
+                                            -75.3053,
+                                            70.8888
+                                        ],
+                                        [
+                                            -73.6706,
+                                            70.5888
+                                        ],
+                                        [
+                                            -72.0715,
+                                            70.2769
+                                        ],
+                                        [
+                                            -70.524,
+                                            69.95
+                                        ],
+                                        [
+                                            -69.0316,
+                                            69.6115
+                                        ],
+                                        [
+                                            -67.5763,
+                                            69.2572
+                                        ],
+                                        [
+                                            -62.6829,
+                                            71.4034
+                                        ],
+                                        [
+                                            -56.6292,
+                                            73.405
+                                        ],
+                                        [
+                                            -49.0938,
+                                            75.1955
+                                        ],
+                                        [
+                                            -39.7646,
+                                            76.6867
+                                        ],
+                                        [
+                                            -41.1296,
+                                            77.2321
+                                        ],
+                                        [
+                                            -42.5948,
+                                            77.7617
+                                        ],
+                                        [
+                                            -44.1928,
+                                            78.2838
+                                        ],
+                                        [
+                                            -45.9368,
+                                            78.7935
+                                        ],
+                                        [
+                                            -47.8232,
+                                            79.2947
+                                        ],
+                                        [
+                                            -49.9073,
+                                            79.7829
+                                        ],
+                                        [
+                                            -52.189,
+                                            80.2574
+                                        ],
+                                        [
+                                            -54.7205,
+                                            80.7143
+                                        ],
+                                        [
+                                            -57.4899,
+                                            81.1529
+                                        ],
+                                        [
+                                            -60.5729,
+                                            81.5686
+                                        ],
+                                        [
+                                            -63.9141,
+                                            81.957
+                                        ],
+                                        [
+                                            -67.5582,
+                                            82.3139
+                                        ],
+                                        [
+                                            -71.5883,
+                                            82.6399
+                                        ],
+                                        [
+                                            -75.9841,
+                                            82.9285
+                                        ],
+                                        [
+                                            -80.735,
+                                            83.1731
+                                        ],
+                                        [
+                                            -85.7393,
+                                            83.3661
+                                        ],
+                                        [
+                                            -90.9868,
+                                            83.5059
+                                        ],
+                                        [
+                                            -96.4407,
+                                            83.5899
+                                        ],
+                                        [
+                                            -102.022,
+                                            83.6158
+                                        ],
+                                        [
+                                            -102.0,
+                                            81.0114
+                                        ],
+                                        [
+                                            -102.157,
+                                            78.404
+                                        ],
+                                        [
+                                            -102.4,
+                                            75.7961
+                                        ],
+                                        [
+                                            -102.694,
+                                            73.1954
+                                        ]
+                                    ]
+                                ]
+                            },
+                            {
+                                "type": "list",
+                                "count": 1,
+                                "value": [
+                                    [
+                                        [
+                                            -76.773,
+                                            83.6125
+                                        ],
+                                        [
+                                            -71.2462,
+                                            83.587
+                                        ],
+                                        [
+                                            -65.7887,
+                                            83.5035
+                                        ],
+                                        [
+                                            -60.4942,
+                                            83.3626
+                                        ],
+                                        [
+                                            -55.4927,
+                                            83.1697
+                                        ],
+                                        [
+                                            -50.7729,
+                                            82.9267
+                                        ],
+                                        [
+                                            -46.3959,
+                                            82.6398
+                                        ],
+                                        [
+                                            -42.3419,
+                                            82.3124
+                                        ],
+                                        [
+                                            -38.667,
+                                            81.9525
+                                        ],
+                                        [
+                                            -35.3189,
+                                            81.563
+                                        ],
+                                        [
+                                            -32.2567,
+                                            81.1499
+                                        ],
+                                        [
+                                            -29.4878,
+                                            80.7115
+                                        ],
+                                        [
+                                            -26.9624,
+                                            80.2558
+                                        ],
+                                        [
+                                            -24.6791,
+                                            79.7813
+                                        ],
+                                        [
+                                            -22.5921,
+                                            79.2925
+                                        ],
+                                        [
+                                            -20.6997,
+                                            78.7898
+                                        ],
+                                        [
+                                            -18.9502,
+                                            78.2784
+                                        ],
+                                        [
+                                            -17.3473,
+                                            77.7544
+                                        ],
+                                        [
+                                            -15.8778,
+                                            77.2229
+                                        ],
+                                        [
+                                            -14.5315,
+                                            76.6847
+                                        ],
+                                        [
+                                            -3.30401,
+                                            77.7701
+                                        ],
+                                        [
+                                            9.51682,
+                                            78.3357
+                                        ],
+                                        [
+                                            22.9242,
+                                            78.3069
+                                        ],
+                                        [
+                                            35.6332,
+                                            77.6868
+                                        ],
+                                        [
+                                            36.6446,
+                                            78.2704
+                                        ],
+                                        [
+                                            37.747,
+                                            78.8472
+                                        ],
+                                        [
+                                            38.9758,
+                                            79.4232
+                                        ],
+                                        [
+                                            40.3292,
+                                            79.9925
+                                        ],
+                                        [
+                                            41.8679,
+                                            80.5534
+                                        ],
+                                        [
+                                            43.5859,
+                                            81.109
+                                        ],
+                                        [
+                                            45.5354,
+                                            81.6544
+                                        ],
+                                        [
+                                            47.7372,
+                                            82.1922
+                                        ],
+                                        [
+                                            50.2687,
+                                            82.7141
+                                        ],
+                                        [
+                                            53.1562,
+                                            83.2221
+                                        ],
+                                        [
+                                            56.5285,
+                                            83.7087
+                                        ],
+                                        [
+                                            60.4328,
+                                            84.1685
+                                        ],
+                                        [
+                                            64.9802,
+                                            84.5986
+                                        ],
+                                        [
+                                            70.2927,
+                                            84.9896
+                                        ],
+                                        [
+                                            76.3929,
+                                            85.3285
+                                        ],
+                                        [
+                                            83.4254,
+                                            85.6094
+                                        ],
+                                        [
+                                            91.1986,
+                                            85.8145
+                                        ],
+                                        [
+                                            99.6374,
+                                            85.9363
+                                        ],
+                                        [
+                                            108.436,
+                                            85.9654
+                                        ],
+                                        [
+                                            112.12,
+                                            88.566
+                                        ],
+                                        [
+                                            -82.1986,
+                                            88.8095
+                                        ],
+                                        [
+                                            -77.3746,
+                                            86.2134
+                                        ],
+                                        [
+                                            -76.773,
+                                            83.6125
+                                        ]
+                                    ]
+                                ]
+                            },
+                            {
+                                "type": "list",
+                                "count": 1,
+                                "value": [
+                                    [
+                                        [
+                                            148.242,
+                                            20.7671
+                                        ],
+                                        [
+                                            148.896,
+                                            20.6592
+                                        ],
+                                        [
+                                            149.549,
+                                            20.5499
+                                        ],
+                                        [
+                                            150.198,
+                                            20.4388
+                                        ],
+                                        [
+                                            150.852,
+                                            20.3241
+                                        ],
+                                        [
+                                            151.503,
+                                            20.2075
+                                        ],
+                                        [
+                                            152.152,
+                                            20.0886
+                                        ],
+                                        [
+                                            152.797,
+                                            19.9685
+                                        ],
+                                        [
+                                            153.445,
+                                            19.8444
+                                        ],
+                                        [
+                                            154.093,
+                                            19.7178
+                                        ],
+                                        [
+                                            154.738,
+                                            19.5925
+                                        ],
+                                        [
+                                            155.38,
+                                            19.4619
+                                        ],
+                                        [
+                                            156.025,
+                                            19.3309
+                                        ],
+                                        [
+                                            156.666,
+                                            19.1948
+                                        ],
+                                        [
+                                            157.306,
+                                            19.0576
+                                        ],
+                                        [
+                                            157.946,
+                                            18.9153
+                                        ],
+                                        [
+                                            158.587,
+                                            18.7748
+                                        ],
+                                        [
+                                            159.224,
+                                            18.6309
+                                        ],
+                                        [
+                                            159.859,
+                                            18.4851
+                                        ],
+                                        [
+                                            160.495,
+                                            18.3364
+                                        ],
+                                        [
+                                            161.188,
+                                            20.9786
+                                        ],
+                                        [
+                                            161.909,
+                                            23.6194
+                                        ],
+                                        [
+                                            162.658,
+                                            26.2598
+                                        ],
+                                        [
+                                            163.439,
+                                            28.8959
+                                        ],
+                                        [
+                                            162.754,
+                                            29.0557
+                                        ],
+                                        [
+                                            162.067,
+                                            29.2115
+                                        ],
+                                        [
+                                            161.377,
+                                            29.3639
+                                        ],
+                                        [
+                                            160.685,
+                                            29.5111
+                                        ],
+                                        [
+                                            159.99,
+                                            29.6592
+                                        ],
+                                        [
+                                            159.294,
+                                            29.8007
+                                        ],
+                                        [
+                                            158.599,
+                                            29.9392
+                                        ],
+                                        [
+                                            157.899,
+                                            30.0712
+                                        ],
+                                        [
+                                            157.196,
+                                            30.2024
+                                        ],
+                                        [
+                                            156.491,
+                                            30.3263
+                                        ],
+                                        [
+                                            155.787,
+                                            30.4493
+                                        ],
+                                        [
+                                            155.078,
+                                            30.569
+                                        ],
+                                        [
+                                            154.373,
+                                            30.6832
+                                        ],
+                                        [
+                                            153.663,
+                                            30.7946
+                                        ],
+                                        [
+                                            152.95,
+                                            30.9023
+                                        ],
+                                        [
+                                            152.239,
+                                            31.0055
+                                        ],
+                                        [
+                                            151.521,
+                                            31.1056
+                                        ],
+                                        [
+                                            150.804,
+                                            31.2014
+                                        ],
+                                        [
+                                            150.088,
+                                            31.2939
+                                        ],
+                                        [
+                                            149.64,
+                                            28.6617
+                                        ],
+                                        [
+                                            149.183,
+                                            26.0268
+                                        ],
+                                        [
+                                            148.716,
+                                            23.3978
+                                        ],
+                                        [
+                                            148.242,
+                                            20.7671
+                                        ]
+                                    ]
+                                ]
+                            },
+                            {
+                                "type": "list",
+                                "count": 1,
+                                "value": [
+                                    [
+                                        [
+                                            7.41228,
+                                            85.9504
+                                        ],
+                                        [
+                                            -1.36652,
+                                            85.921
+                                        ],
+                                        [
+                                            -9.77385,
+                                            85.7993
+                                        ],
+                                        [
+                                            -17.522,
+                                            85.5944
+                                        ],
+                                        [
+                                            -24.4845,
+                                            85.3165
+                                        ],
+                                        [
+                                            -30.6208,
+                                            84.9758
+                                        ],
+                                        [
+                                            -35.9252,
+                                            84.5856
+                                        ],
+                                        [
+                                            -40.4685,
+                                            84.1562
+                                        ],
+                                        [
+                                            -44.3715,
+                                            83.697
+                                        ],
+                                        [
+                                            -47.7441,
+                                            83.2111
+                                        ],
+                                        [
+                                            -50.6332,
+                                            82.7038
+                                        ],
+                                        [
+                                            -53.1667,
+                                            82.1824
+                                        ],
+                                        [
+                                            -55.3755,
+                                            81.644
+                                        ],
+                                        [
+                                            -57.3271,
+                                            81.0993
+                                        ],
+                                        [
+                                            -59.0447,
+                                            80.5451
+                                        ],
+                                        [
+                                            -60.5848,
+                                            79.9852
+                                        ],
+                                        [
+                                            -61.9387,
+                                            79.4174
+                                        ],
+                                        [
+                                            -63.1675,
+                                            78.8433
+                                        ],
+                                        [
+                                            -64.2738,
+                                            78.2665
+                                        ],
+                                        [
+                                            -65.2935,
+                                            77.6799
+                                        ],
+                                        [
+                                            -49.0428,
+                                            75.7585
+                                        ],
+                                        [
+                                            -47.5299,
+                                            76.2688
+                                        ],
+                                        [
+                                            -45.9372,
+                                            76.7618
+                                        ],
+                                        [
+                                            -44.2291,
+                                            77.2429
+                                        ],
+                                        [
+                                            -42.3891,
+                                            77.7154
+                                        ],
+                                        [
+                                            -40.3982,
+                                            78.1696
+                                        ],
+                                        [
+                                            -38.2576,
+                                            78.6116
+                                        ],
+                                        [
+                                            -35.9463,
+                                            79.0355
+                                        ],
+                                        [
+                                            -33.4592,
+                                            79.4447
+                                        ],
+                                        [
+                                            -30.7754,
+                                            79.8301
+                                        ],
+                                        [
+                                            -27.8982,
+                                            80.1955
+                                        ],
+                                        [
+                                            -24.7629,
+                                            80.5354
+                                        ],
+                                        [
+                                            -21.451,
+                                            80.8417
+                                        ],
+                                        [
+                                            -17.9135,
+                                            81.1179
+                                        ],
+                                        [
+                                            -14.1954,
+                                            81.3561
+                                        ],
+                                        [
+                                            -10.2195,
+                                            81.5595
+                                        ],
+                                        [
+                                            -6.12066,
+                                            81.7193
+                                        ],
+                                        [
+                                            -1.85442,
+                                            81.8364
+                                        ],
+                                        [
+                                            2.49267,
+                                            81.9076
+                                        ],
+                                        [
+                                            6.90091,
+                                            81.9316
+                                        ],
+                                        [
+                                            7.41228,
+                                            85.9504
+                                        ]
+                                    ]
+                                ]
+                            }
+                        ]
+                    }
+                },
+                "key_sets": {
+                    "type": "distinct",
+                    "values": [
+                        {
+                            "keys": [
+                                "type",
+                                "coordinates"
+                            ],
+                            "count_with": 263463
+                        }
+                    ]
+                }
+            }
+        },
+        "links": {
+            "type": "object-list",
+            "count_with": 263463,
+            "count_without": 0,
+            "values": [
+                {
+                    "count": 263463,
+                    "keys": {
+                        "rel": {
+                            "type": "distinct",
+                            "count_with": 263463,
+                            "count_without": 0,
+                            "values": [
+                                {
+                                    "type": "string",
+                                    "count": 263463,
+                                    "value": "license"
+                                }
+                            ]
+                        },
+                        "href": {
+                            "type": "distinct",
+                            "count_with": 263463,
+                            "count_without": 0,
+                            "values": [
+                                {
+                                    "type": "string",
+                                    "count": 263463,
+                                    "value": "https://sentinel.esa.int/documents/247904/690755/Sentinel_Data_Legal_Notice"
+                                }
+                            ]
+                        }
+                    },
+                    "key_sets": {
+                        "type": "distinct",
+                        "values": [
+                            {
+                                "keys": [
+                                    "rel",
+                                    "href"
+                                ],
+                                "count_with": 263463
+                            }
+                        ]
+                    }
+                }
+            ]
+        },
+        "assets": {
+            "type": "object",
+            "count_with": 263463,
+            "count_without": 0,
+            "summary": {
+                "count": 263463,
+                "keys": {
+                    "safe-manifest": {
+                        "type": "object",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "summary": {
+                            "count": 263463,
+                            "keys": {
+                                "href": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/xfdumanifest.xml"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/xfdumanifest.xml"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/xfdumanifest.xml"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/xfdumanifest.xml"
+                                        }
+                                    ]
+                                },
+                                "type": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "application/xml"
+                                        }
+                                    ]
+                                },
+                                "file:checksum": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "d730b14d5a0d70f15225b7da7cacf1b1"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "1cff266402645c4ab9c655e9a22db35e"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "fe033505238ebdf9a4faf387a43f5c97"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "39c7c471088309aee5161532a192bf3e"
+                                        }
+                                    ]
+                                },
+                                "file:local_path": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/xfdumanifest.xml"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/xfdumanifest.xml"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/xfdumanifest.xml"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/xfdumanifest.xml"
+                                        }
+                                    ]
+                                },
+                                "file:size": {
+                                    "type": "int-range",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "min": 61971,
+                                    "max": 1855239
+                                },
+                                "roles": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                "metadata"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "key_sets": {
+                                "type": "distinct",
+                                "values": [
+                                    {
+                                        "keys": [
+                                            "file:size",
+                                            "roles",
+                                            "type",
+                                            "file:checksum",
+                                            "href",
+                                            "file:local_path"
+                                        ],
+                                        "count_with": 263463
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "ogvi": {
+                        "type": "object",
+                        "count_with": 200177,
+                        "count_without": 63286,
+                        "summary": {
+                            "count": 200177,
+                            "keys": {
+                                "href": {
+                                    "type": "mixed-value",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/ogvi.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/ogvi.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/ogvi.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/ogvi.nc"
+                                        }
+                                    ]
+                                },
+                                "type": {
+                                    "type": "distinct",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 200177,
+                                            "value": "application/x-netcdf"
+                                        }
+                                    ]
+                                },
+                                "description": {
+                                    "type": "distinct",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 200177,
+                                            "value": "OLCI global Vegetal Index"
+                                        }
+                                    ]
+                                },
+                                "resolution": {
+                                    "type": "distinct",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 200177,
+                                            "value": [
+                                                270,
+                                                294
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "eo:bands": {
+                                    "type": "object-list",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "count": 200177,
+                                            "keys": {
+                                                "name": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 200177,
+                                                            "value": "Oa03"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 200177,
+                                                            "value": "Band 3 - Chlorophyll absorption maximum, biogeochemistry, vegetation"
+                                                        }
+                                                    ]
+                                                },
+                                                "center_wavelength": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-float",
+                                                            "count": 200177,
+                                                            "value": 442.5
+                                                        }
+                                                    ]
+                                                },
+                                                "band_width": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-int",
+                                                            "count": 200177,
+                                                            "value": 10
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "key_sets": {
+                                                "type": "distinct",
+                                                "values": [
+                                                    {
+                                                        "keys": [
+                                                            "band_width",
+                                                            "description",
+                                                            "center_wavelength",
+                                                            "name"
+                                                        ],
+                                                        "count_with": 200177
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "count": 200177,
+                                            "keys": {
+                                                "name": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 200177,
+                                                            "value": "Oa10"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 200177,
+                                                            "value": "Band 10 - Chlorophyll fluorescence peak, red edge"
+                                                        }
+                                                    ]
+                                                },
+                                                "center_wavelength": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-float",
+                                                            "count": 200177,
+                                                            "value": 681.25
+                                                        }
+                                                    ]
+                                                },
+                                                "band_width": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-float",
+                                                            "count": 200177,
+                                                            "value": 7.5
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "key_sets": {
+                                                "type": "distinct",
+                                                "values": [
+                                                    {
+                                                        "keys": [
+                                                            "band_width",
+                                                            "description",
+                                                            "center_wavelength",
+                                                            "name"
+                                                        ],
+                                                        "count_with": 200177
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "count": 200177,
+                                            "keys": {
+                                                "name": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 200177,
+                                                            "value": "Oa17"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 200177,
+                                                            "value": "Band 17 - Atmospheric / aerosol correction, clouds, pixel co-registration"
+                                                        }
+                                                    ]
+                                                },
+                                                "center_wavelength": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-int",
+                                                            "count": 200177,
+                                                            "value": 865
+                                                        }
+                                                    ]
+                                                },
+                                                "band_width": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-int",
+                                                            "count": 200177,
+                                                            "value": 20
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "key_sets": {
+                                                "type": "distinct",
+                                                "values": [
+                                                    {
+                                                        "keys": [
+                                                            "band_width",
+                                                            "description",
+                                                            "center_wavelength",
+                                                            "name"
+                                                        ],
+                                                        "count_with": 200177
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "file:checksum": {
+                                    "type": "mixed-value",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "15fe079a8b589c2162459e0bb8706fac"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "b1dec90f6a2121321de92f78e4380ba5"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "4c871aa6cd801f7f07d734a0e6a70846"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "b5c28546d47c04a711e9e8907b5c75fb"
+                                        }
+                                    ]
+                                },
+                                "file:local_path": {
+                                    "type": "mixed-value",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/ogvi.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/ogvi.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/ogvi.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/ogvi.nc"
+                                        }
+                                    ]
+                                },
+                                "file:size": {
+                                    "type": "int-range",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "min": 15860,
+                                    "max": 24720792
+                                },
+                                "roles": {
+                                    "type": "distinct",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 200177,
+                                            "value": [
+                                                "data"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "key_sets": {
+                                "type": "distinct",
+                                "values": [
+                                    {
+                                        "keys": [
+                                            "resolution",
+                                            "file:size",
+                                            "roles",
+                                            "description",
+                                            "eo:bands",
+                                            "type",
+                                            "file:checksum",
+                                            "href",
+                                            "file:local_path"
+                                        ],
+                                        "count_with": 200177
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "otci": {
+                        "type": "object",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "summary": {
+                            "count": 263463,
+                            "keys": {
+                                "href": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/otci.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/otci.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/otci.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/otci.nc"
+                                        }
+                                    ]
+                                },
+                                "type": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "application/x-netcdf"
+                                        }
+                                    ]
+                                },
+                                "description": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "OLCI Terrestrial Chlorophyll Index"
+                                        }
+                                    ]
+                                },
+                                "resolution": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                270,
+                                                294
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "eo:bands": {
+                                    "type": "object-list",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "count": 263463,
+                                            "keys": {
+                                                "name": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 263463,
+                                                            "value": "Oa10"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 263463,
+                                                            "value": "Band 10 - Chlorophyll fluorescence peak, red edge"
+                                                        }
+                                                    ]
+                                                },
+                                                "center_wavelength": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-float",
+                                                            "count": 263463,
+                                                            "value": 681.25
+                                                        }
+                                                    ]
+                                                },
+                                                "band_width": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-float",
+                                                            "count": 263463,
+                                                            "value": 7.5
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "key_sets": {
+                                                "type": "distinct",
+                                                "values": [
+                                                    {
+                                                        "keys": [
+                                                            "band_width",
+                                                            "description",
+                                                            "center_wavelength",
+                                                            "name"
+                                                        ],
+                                                        "count_with": 263463
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "count": 263463,
+                                            "keys": {
+                                                "name": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 263463,
+                                                            "value": "Oa11"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 263463,
+                                                            "value": "Band 11 - Chlorophyll fluorescence baseline, red edge transition"
+                                                        }
+                                                    ]
+                                                },
+                                                "center_wavelength": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-float",
+                                                            "count": 263463,
+                                                            "value": 708.75
+                                                        }
+                                                    ]
+                                                },
+                                                "band_width": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-int",
+                                                            "count": 263463,
+                                                            "value": 10
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "key_sets": {
+                                                "type": "distinct",
+                                                "values": [
+                                                    {
+                                                        "keys": [
+                                                            "band_width",
+                                                            "description",
+                                                            "center_wavelength",
+                                                            "name"
+                                                        ],
+                                                        "count_with": 263463
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "count": 263463,
+                                            "keys": {
+                                                "name": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 263463,
+                                                            "value": "Oa12"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 263463,
+                                                            "value": "Band 12 - O2 absorption / clouds, vegetation"
+                                                        }
+                                                    ]
+                                                },
+                                                "center_wavelength": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-float",
+                                                            "count": 263463,
+                                                            "value": 753.75
+                                                        }
+                                                    ]
+                                                },
+                                                "band_width": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-float",
+                                                            "count": 263463,
+                                                            "value": 7.5
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "key_sets": {
+                                                "type": "distinct",
+                                                "values": [
+                                                    {
+                                                        "keys": [
+                                                            "band_width",
+                                                            "description",
+                                                            "center_wavelength",
+                                                            "name"
+                                                        ],
+                                                        "count_with": 263463
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "file:checksum": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "07bea9fbb5a4103bddd75efb10202097"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "2031f894885f895a4ec15d52802213e7"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "6ebc329d1a91d5b8011e796aa79872b7"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "e9530eb254f305384df6d447f4be2dff"
+                                        }
+                                    ]
+                                },
+                                "file:local_path": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/otci.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/otci.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/otci.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/otci.nc"
+                                        }
+                                    ]
+                                },
+                                "file:size": {
+                                    "type": "int-range",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "min": 19412,
+                                    "max": 17772510
+                                },
+                                "roles": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                "data"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "key_sets": {
+                                "type": "distinct",
+                                "values": [
+                                    {
+                                        "keys": [
+                                            "resolution",
+                                            "file:size",
+                                            "roles",
+                                            "description",
+                                            "eo:bands",
+                                            "type",
+                                            "file:checksum",
+                                            "href",
+                                            "file:local_path"
+                                        ],
+                                        "count_with": 263463
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "iwv": {
+                        "type": "object",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "summary": {
+                            "count": 263463,
+                            "keys": {
+                                "href": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/iwv.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/iwv.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/iwv.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/iwv.nc"
+                                        }
+                                    ]
+                                },
+                                "type": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "application/x-netcdf"
+                                        }
+                                    ]
+                                },
+                                "description": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "Integrated water vapour column"
+                                        }
+                                    ]
+                                },
+                                "resolution": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                270,
+                                                294
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "eo:bands": {
+                                    "type": "object-list",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "count": 263463,
+                                            "keys": {
+                                                "name": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 263463,
+                                                            "value": "Oa18"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 263463,
+                                                            "value": "Band 18 - Water vapour absorption reference. Common reference band with SLSTR. Vegetation monitoring"
+                                                        }
+                                                    ]
+                                                },
+                                                "center_wavelength": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-int",
+                                                            "count": 263463,
+                                                            "value": 885
+                                                        }
+                                                    ]
+                                                },
+                                                "band_width": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-int",
+                                                            "count": 263463,
+                                                            "value": 10
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "key_sets": {
+                                                "type": "distinct",
+                                                "values": [
+                                                    {
+                                                        "keys": [
+                                                            "band_width",
+                                                            "description",
+                                                            "center_wavelength",
+                                                            "name"
+                                                        ],
+                                                        "count_with": 263463
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "count": 263463,
+                                            "keys": {
+                                                "name": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 263463,
+                                                            "value": "Oa19"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 263463,
+                                                            "value": "Band 19 - Water vapour absorption, vegetation monitoring (maximum REFLECTANCE)"
+                                                        }
+                                                    ]
+                                                },
+                                                "center_wavelength": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-int",
+                                                            "count": 263463,
+                                                            "value": 900
+                                                        }
+                                                    ]
+                                                },
+                                                "band_width": {
+                                                    "type": "distinct",
+                                                    "count_with": 263463,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-int",
+                                                            "count": 263463,
+                                                            "value": 10
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "key_sets": {
+                                                "type": "distinct",
+                                                "values": [
+                                                    {
+                                                        "keys": [
+                                                            "band_width",
+                                                            "description",
+                                                            "center_wavelength",
+                                                            "name"
+                                                        ],
+                                                        "count_with": 263463
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "file:checksum": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "65a1c4dc36ebf89da3e5ad3589c000e7"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "fdff55910dde2552e1af4aa9f64de01b"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "81fa0c692c5dbe6005dc94be95288fe0"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "eb3aa9c09c507192acfc4fa5344bbcd2"
+                                        }
+                                    ]
+                                },
+                                "file:local_path": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/iwv.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/iwv.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/iwv.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/iwv.nc"
+                                        }
+                                    ]
+                                },
+                                "file:size": {
+                                    "type": "int-range",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "min": 15965,
+                                    "max": 26713373
+                                },
+                                "roles": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                "data"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "key_sets": {
+                                "type": "distinct",
+                                "values": [
+                                    {
+                                        "keys": [
+                                            "resolution",
+                                            "file:size",
+                                            "roles",
+                                            "description",
+                                            "eo:bands",
+                                            "type",
+                                            "file:checksum",
+                                            "href",
+                                            "file:local_path"
+                                        ],
+                                        "count_with": 263463
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "rcOgvi": {
+                        "type": "object",
+                        "count_with": 200177,
+                        "count_without": 63286,
+                        "summary": {
+                            "count": 200177,
+                            "keys": {
+                                "href": {
+                                    "type": "mixed-value",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/rc_ogvi.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/rc_ogvi.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/rc_ogvi.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/rc_ogvi.nc"
+                                        }
+                                    ]
+                                },
+                                "type": {
+                                    "type": "distinct",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 200177,
+                                            "value": "application/x-netcdf"
+                                        }
+                                    ]
+                                },
+                                "description": {
+                                    "type": "distinct",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 200177,
+                                            "value": "Rectified Reflectance"
+                                        }
+                                    ]
+                                },
+                                "resolution": {
+                                    "type": "distinct",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 200177,
+                                            "value": [
+                                                270,
+                                                294
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "eo:bands": {
+                                    "type": "object-list",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "count": 200177,
+                                            "keys": {
+                                                "name": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 200177,
+                                                            "value": "Oa10"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 200177,
+                                                            "value": "Band 10 - Chlorophyll fluorescence peak, red edge"
+                                                        }
+                                                    ]
+                                                },
+                                                "center_wavelength": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-float",
+                                                            "count": 200177,
+                                                            "value": 681.25
+                                                        }
+                                                    ]
+                                                },
+                                                "band_width": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-float",
+                                                            "count": 200177,
+                                                            "value": 7.5
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "key_sets": {
+                                                "type": "distinct",
+                                                "values": [
+                                                    {
+                                                        "keys": [
+                                                            "band_width",
+                                                            "description",
+                                                            "center_wavelength",
+                                                            "name"
+                                                        ],
+                                                        "count_with": 200177
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "count": 200177,
+                                            "keys": {
+                                                "name": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 200177,
+                                                            "value": "Oa17"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 200177,
+                                                            "value": "Band 17 - Atmospheric / aerosol correction, clouds, pixel co-registration"
+                                                        }
+                                                    ]
+                                                },
+                                                "center_wavelength": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-int",
+                                                            "count": 200177,
+                                                            "value": 865
+                                                        }
+                                                    ]
+                                                },
+                                                "band_width": {
+                                                    "type": "distinct",
+                                                    "count_with": 200177,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-int",
+                                                            "count": 200177,
+                                                            "value": 20
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "key_sets": {
+                                                "type": "distinct",
+                                                "values": [
+                                                    {
+                                                        "keys": [
+                                                            "band_width",
+                                                            "description",
+                                                            "center_wavelength",
+                                                            "name"
+                                                        ],
+                                                        "count_with": 200177
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "file:checksum": {
+                                    "type": "mixed-value",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "9777f52eb5a5cd2db1a68ce3a2dc95c3"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "7a3d5d7bfc1c7e379dec6e389569e41c"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "e86b2e3a4129411bf3aa214a381c184d"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "01662bd738a27cfff6ddc4ca1d1ad150"
+                                        }
+                                    ]
+                                },
+                                "file:local_path": {
+                                    "type": "mixed-value",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/rc_ogvi.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/rc_ogvi.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/rc_ogvi.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/rc_ogvi.nc"
+                                        }
+                                    ]
+                                },
+                                "file:size": {
+                                    "type": "int-range",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "min": 23029,
+                                    "max": 61712530
+                                },
+                                "roles": {
+                                    "type": "distinct",
+                                    "count_with": 200177,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 200177,
+                                            "value": [
+                                                "data"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "key_sets": {
+                                "type": "distinct",
+                                "values": [
+                                    {
+                                        "keys": [
+                                            "resolution",
+                                            "file:size",
+                                            "roles",
+                                            "description",
+                                            "eo:bands",
+                                            "type",
+                                            "file:checksum",
+                                            "href",
+                                            "file:local_path"
+                                        ],
+                                        "count_with": 200177
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "lqsf": {
+                        "type": "object",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "summary": {
+                            "count": 263463,
+                            "keys": {
+                                "href": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/lqsf.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/lqsf.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/lqsf.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/lqsf.nc"
+                                        }
+                                    ]
+                                },
+                                "type": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "application/x-netcdf"
+                                        }
+                                    ]
+                                },
+                                "description": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "Land Quality and Science Flags"
+                                        }
+                                    ]
+                                },
+                                "resolution": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                270,
+                                                294
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "file:checksum": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "3cbf37e58204be0cd099c669c8a3b517"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "1d93396bf1ae374ac3d1a9a53a51d6b9"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "f1229186ed9705212a46042a3838e8f9"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "7eb3c6ac35de1d36822d651536bec5ae"
+                                        }
+                                    ]
+                                },
+                                "file:local_path": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/lqsf.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/lqsf.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/lqsf.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/lqsf.nc"
+                                        }
+                                    ]
+                                },
+                                "file:size": {
+                                    "type": "int-range",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "min": 12925,
+                                    "max": 11664718
+                                },
+                                "roles": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                "data"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "key_sets": {
+                                "type": "distinct",
+                                "values": [
+                                    {
+                                        "keys": [
+                                            "resolution",
+                                            "file:size",
+                                            "roles",
+                                            "description",
+                                            "type",
+                                            "file:checksum",
+                                            "href",
+                                            "file:local_path"
+                                        ],
+                                        "count_with": 263463
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "timeCoordinates": {
+                        "type": "object",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "summary": {
+                            "count": 263463,
+                            "keys": {
+                                "href": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/time_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/time_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/time_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/time_coordinates.nc"
+                                        }
+                                    ]
+                                },
+                                "type": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "application/x-netcdf"
+                                        }
+                                    ]
+                                },
+                                "description": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "Time Coordinates Annotations"
+                                        }
+                                    ]
+                                },
+                                "resolution": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                270,
+                                                294
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "file:checksum": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "410beaeddc161d519b6a9e2601b783f1"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "2da83ba6fdb13bbf4dad4c12fd13c4db"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "625287d261905992c1e4358c3ddb9830"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "f3ece36902c9f2c4957c24651abc54a3"
+                                        }
+                                    ]
+                                },
+                                "file:local_path": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/time_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/time_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/time_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/time_coordinates.nc"
+                                        }
+                                    ]
+                                },
+                                "file:size": {
+                                    "type": "int-range",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "min": 11313,
+                                    "max": 16002
+                                },
+                                "roles": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                "data"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "key_sets": {
+                                "type": "distinct",
+                                "values": [
+                                    {
+                                        "keys": [
+                                            "resolution",
+                                            "file:size",
+                                            "roles",
+                                            "description",
+                                            "type",
+                                            "file:checksum",
+                                            "href",
+                                            "file:local_path"
+                                        ],
+                                        "count_with": 263463
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "geoCoordinates": {
+                        "type": "object",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "summary": {
+                            "count": 263463,
+                            "keys": {
+                                "href": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/geo_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/geo_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/geo_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/geo_coordinates.nc"
+                                        }
+                                    ]
+                                },
+                                "type": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "application/x-netcdf"
+                                        }
+                                    ]
+                                },
+                                "description": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "Geo Coordinates Annotations"
+                                        }
+                                    ]
+                                },
+                                "resolution": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                270,
+                                                294
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "file:checksum": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "f3778f19e32847e344bad4e79fae431c"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "33593d5e585d56cbb63b8d9ad2992f32"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "4bbcd2fc57a69ea12732f8dfa82d8817"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "e2aef4949d8c11505e100c961b5b49ca"
+                                        }
+                                    ]
+                                },
+                                "file:local_path": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/geo_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/geo_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/geo_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/geo_coordinates.nc"
+                                        }
+                                    ]
+                                },
+                                "file:size": {
+                                    "type": "int-range",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "min": 78650,
+                                    "max": 75389534
+                                },
+                                "roles": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                "data"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "key_sets": {
+                                "type": "distinct",
+                                "values": [
+                                    {
+                                        "keys": [
+                                            "resolution",
+                                            "file:size",
+                                            "roles",
+                                            "description",
+                                            "type",
+                                            "file:checksum",
+                                            "href",
+                                            "file:local_path"
+                                        ],
+                                        "count_with": 263463
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "tieGeoCoordinates": {
+                        "type": "object",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "summary": {
+                            "count": 263463,
+                            "keys": {
+                                "href": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/tie_geo_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/tie_geo_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/tie_geo_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/tie_geo_coordinates.nc"
+                                        }
+                                    ]
+                                },
+                                "type": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "application/x-netcdf"
+                                        }
+                                    ]
+                                },
+                                "description": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "Tie-Point Geo Coordinate Annotations"
+                                        }
+                                    ]
+                                },
+                                "resolution": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                270,
+                                                294
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "file:checksum": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "f7125cde43d381ede53a3f4e43834b33"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "67aa1036a3fe2b777f80e3a92466e9a9"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "23be4c588db7aa2d0f518b9e8a7ef26e"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "8ae36920ba4a7e222df1cca67311c96d"
+                                        }
+                                    ]
+                                },
+                                "file:local_path": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/tie_geo_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/tie_geo_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/tie_geo_coordinates.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/tie_geo_coordinates.nc"
+                                        }
+                                    ]
+                                },
+                                "file:size": {
+                                    "type": "int-range",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "min": 17064,
+                                    "max": 1437520
+                                },
+                                "roles": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                "data"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "key_sets": {
+                                "type": "distinct",
+                                "values": [
+                                    {
+                                        "keys": [
+                                            "resolution",
+                                            "file:size",
+                                            "roles",
+                                            "description",
+                                            "type",
+                                            "file:checksum",
+                                            "href",
+                                            "file:local_path"
+                                        ],
+                                        "count_with": 263463
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "tieGeometries": {
+                        "type": "object",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "summary": {
+                            "count": 263463,
+                            "keys": {
+                                "href": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/tie_geometries.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/tie_geometries.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/tie_geometries.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/tie_geometries.nc"
+                                        }
+                                    ]
+                                },
+                                "type": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "application/x-netcdf"
+                                        }
+                                    ]
+                                },
+                                "description": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "Tie-Point Geometries Annotations"
+                                        }
+                                    ]
+                                },
+                                "resolution": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                270,
+                                                294
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "file:checksum": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "bb8c525e94d9cf14d2e73f08e7971b05"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "0579d6fb9455c207975b19c319a313f9"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "13c5eca80ab6efe7483d3d108a8b9746"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "2fde7b1bc6b176afb27760f17bc43824"
+                                        }
+                                    ]
+                                },
+                                "file:local_path": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/tie_geometries.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/tie_geometries.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/tie_geometries.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/tie_geometries.nc"
+                                        }
+                                    ]
+                                },
+                                "file:size": {
+                                    "type": "int-range",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "min": 24941,
+                                    "max": 2584420
+                                },
+                                "roles": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                "data"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "key_sets": {
+                                "type": "distinct",
+                                "values": [
+                                    {
+                                        "keys": [
+                                            "resolution",
+                                            "file:size",
+                                            "roles",
+                                            "description",
+                                            "type",
+                                            "file:checksum",
+                                            "href",
+                                            "file:local_path"
+                                        ],
+                                        "count_with": 263463
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "tieMeteo": {
+                        "type": "object",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "summary": {
+                            "count": 263463,
+                            "keys": {
+                                "href": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/tie_meteo.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/tie_meteo.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/tie_meteo.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/tie_meteo.nc"
+                                        }
+                                    ]
+                                },
+                                "type": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "application/x-netcdf"
+                                        }
+                                    ]
+                                },
+                                "description": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "Tie-Point Meteo Annotations"
+                                        }
+                                    ]
+                                },
+                                "resolution": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                270,
+                                                294
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "file:checksum": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "9425c1d8ade24215dfc09eb9725cafe2"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "c879bf8922c8f2367833e2794377ebfe"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "808c164f6508a9a3adfad378a5dd2060"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "91f7a3f893d2647c74d723468980630c"
+                                        }
+                                    ]
+                                },
+                                "file:local_path": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/tie_meteo.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/tie_meteo.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/tie_meteo.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/tie_meteo.nc"
+                                        }
+                                    ]
+                                },
+                                "file:size": {
+                                    "type": "int-range",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "min": 52454,
+                                    "max": 21788864
+                                },
+                                "roles": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                "data"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "key_sets": {
+                                "type": "distinct",
+                                "values": [
+                                    {
+                                        "keys": [
+                                            "resolution",
+                                            "file:size",
+                                            "roles",
+                                            "description",
+                                            "type",
+                                            "file:checksum",
+                                            "href",
+                                            "file:local_path"
+                                        ],
+                                        "count_with": 263463
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "instrumentData": {
+                        "type": "object",
+                        "count_with": 263463,
+                        "count_without": 0,
+                        "summary": {
+                            "count": 263463,
+                            "keys": {
+                                "href": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/instrument_data.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/instrument_data.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/instrument_data.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2016/04/25/S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/instrument_data.nc"
+                                        }
+                                    ]
+                                },
+                                "type": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "application/x-netcdf"
+                                        }
+                                    ]
+                                },
+                                "description": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 263463,
+                                            "value": "Instrument Annotation"
+                                        }
+                                    ]
+                                },
+                                "resolution": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                270,
+                                                294
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "file:checksum": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "474bda1e9b032090c746f31a3d7b6f08"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "1f809ba5a5938a932b98812b8e1133ab"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "a37044d27f35c2363ffadbc4b0f9d6f0"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "588967cac5860265fb85f50ead4209ac"
+                                        }
+                                    ]
+                                },
+                                "file:local_path": {
+                                    "type": "mixed-value",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T164019_20160425T164319_20180201T192156_0179_003_240_1620_LR2_R_NT_002.SEN3/instrument_data.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T145619_20160425T145919_20180201T191717_0179_003_239_1440_LR2_R_NT_002.SEN3/instrument_data.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T233915_20160425T234215_20180201T192307_0179_003_244_2520_LR2_R_NT_002.SEN3/instrument_data.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20160425T213907_20160425T214016_20180201T191656_0069_003_243_1260_LR2_R_NT_002.SEN3/instrument_data.nc"
+                                        }
+                                    ]
+                                },
+                                "file:size": {
+                                    "type": "int-range",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "min": 286059,
+                                    "max": 1441096
+                                },
+                                "roles": {
+                                    "type": "distinct",
+                                    "count_with": 263463,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 263463,
+                                            "value": [
+                                                "data"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "key_sets": {
+                                "type": "distinct",
+                                "values": [
+                                    {
+                                        "keys": [
+                                            "resolution",
+                                            "file:size",
+                                            "roles",
+                                            "description",
+                                            "type",
+                                            "file:checksum",
+                                            "href",
+                                            "file:local_path"
+                                        ],
+                                        "count_with": 263463
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "gifapar": {
+                        "type": "object",
+                        "count_with": 63286,
+                        "count_without": 200177,
+                        "summary": {
+                            "count": 63286,
+                            "keys": {
+                                "href": {
+                                    "type": "mixed-value",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2021/07/29/S3B_OL_2_LFR____20210729T075340_20210729T075640_20210729T095309_0180_055_149_2880_LN1_O_NR_002.SEN3/gifapar.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2021/07/29/S3B_OL_2_LFR____20210729T093439_20210729T093739_20210729T114621_0180_055_150_2880_LN1_O_NR_002.SEN3/gifapar.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2021/07/29/S3A_OL_2_LFR____20210729T080901_20210729T081201_20210729T103311_0179_074_292_1440_LN1_O_NR_002.SEN3/gifapar.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2021/07/29/S3B_OL_2_LFR____20210729T074740_20210729T075040_20210729T095406_0179_055_149_2520_LN1_O_NR_002.SEN3/gifapar.nc"
+                                        }
+                                    ]
+                                },
+                                "type": {
+                                    "type": "distinct",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 63286,
+                                            "value": "application/x-netcdf"
+                                        }
+                                    ]
+                                },
+                                "description": {
+                                    "type": "distinct",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 63286,
+                                            "value": "Green Instantaneous FAPAR"
+                                        }
+                                    ]
+                                },
+                                "resolution": {
+                                    "type": "distinct",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 63286,
+                                            "value": [
+                                                270,
+                                                294
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "eo:bands": {
+                                    "type": "object-list",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "count": 63286,
+                                            "keys": {
+                                                "name": {
+                                                    "type": "distinct",
+                                                    "count_with": 63286,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 63286,
+                                                            "value": "Oa03"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": {
+                                                    "type": "distinct",
+                                                    "count_with": 63286,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 63286,
+                                                            "value": "Band 3 - Chlorophyll absorption maximum, biogeochemistry, vegetation"
+                                                        }
+                                                    ]
+                                                },
+                                                "center_wavelength": {
+                                                    "type": "distinct",
+                                                    "count_with": 63286,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-float",
+                                                            "count": 63286,
+                                                            "value": 442.5
+                                                        }
+                                                    ]
+                                                },
+                                                "band_width": {
+                                                    "type": "distinct",
+                                                    "count_with": 63286,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-int",
+                                                            "count": 63286,
+                                                            "value": 10
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "key_sets": {
+                                                "type": "distinct",
+                                                "values": [
+                                                    {
+                                                        "keys": [
+                                                            "description",
+                                                            "band_width",
+                                                            "center_wavelength",
+                                                            "name"
+                                                        ],
+                                                        "count_with": 63286
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "count": 63286,
+                                            "keys": {
+                                                "name": {
+                                                    "type": "distinct",
+                                                    "count_with": 63286,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 63286,
+                                                            "value": "Oa10"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": {
+                                                    "type": "distinct",
+                                                    "count_with": 63286,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 63286,
+                                                            "value": "Band 10 - Chlorophyll fluorescence peak, red edge"
+                                                        }
+                                                    ]
+                                                },
+                                                "center_wavelength": {
+                                                    "type": "distinct",
+                                                    "count_with": 63286,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-float",
+                                                            "count": 63286,
+                                                            "value": 681.25
+                                                        }
+                                                    ]
+                                                },
+                                                "band_width": {
+                                                    "type": "distinct",
+                                                    "count_with": 63286,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-float",
+                                                            "count": 63286,
+                                                            "value": 7.5
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "key_sets": {
+                                                "type": "distinct",
+                                                "values": [
+                                                    {
+                                                        "keys": [
+                                                            "description",
+                                                            "band_width",
+                                                            "center_wavelength",
+                                                            "name"
+                                                        ],
+                                                        "count_with": 63286
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        {
+                                            "count": 63286,
+                                            "keys": {
+                                                "name": {
+                                                    "type": "distinct",
+                                                    "count_with": 63286,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 63286,
+                                                            "value": "Oa17"
+                                                        }
+                                                    ]
+                                                },
+                                                "description": {
+                                                    "type": "distinct",
+                                                    "count_with": 63286,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "string",
+                                                            "count": 63286,
+                                                            "value": "Band 17 - Atmospheric / aerosol correction, clouds, pixel co-registration"
+                                                        }
+                                                    ]
+                                                },
+                                                "center_wavelength": {
+                                                    "type": "distinct",
+                                                    "count_with": 63286,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-int",
+                                                            "count": 63286,
+                                                            "value": 865
+                                                        }
+                                                    ]
+                                                },
+                                                "band_width": {
+                                                    "type": "distinct",
+                                                    "count_with": 63286,
+                                                    "count_without": 0,
+                                                    "values": [
+                                                        {
+                                                            "type": "numeric-int",
+                                                            "count": 63286,
+                                                            "value": 20
+                                                        }
+                                                    ]
+                                                }
+                                            },
+                                            "key_sets": {
+                                                "type": "distinct",
+                                                "values": [
+                                                    {
+                                                        "keys": [
+                                                            "description",
+                                                            "band_width",
+                                                            "center_wavelength",
+                                                            "name"
+                                                        ],
+                                                        "count_with": 63286
+                                                    }
+                                                ]
+                                            }
+                                        }
+                                    ]
+                                },
+                                "file:checksum": {
+                                    "type": "mixed-value",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "65d5024dcc2e70d365870a34c48c0700"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "9129fc20afc23ee9114e116a3f7443c1"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "7ffa596c02712f8f61703f82e5f1a280"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "d83f5a475b49691d33915641a8952d4a"
+                                        }
+                                    ]
+                                },
+                                "file:local_path": {
+                                    "type": "mixed-value",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3B_OL_2_LFR____20210729T075340_20210729T075640_20210729T095309_0180_055_149_2880_LN1_O_NR_002.SEN3/gifapar.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3B_OL_2_LFR____20210729T093439_20210729T093739_20210729T114621_0180_055_150_2880_LN1_O_NR_002.SEN3/gifapar.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20210729T080901_20210729T081201_20210729T103311_0179_074_292_1440_LN1_O_NR_002.SEN3/gifapar.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3B_OL_2_LFR____20210729T074740_20210729T075040_20210729T095406_0179_055_149_2520_LN1_O_NR_002.SEN3/gifapar.nc"
+                                        }
+                                    ]
+                                },
+                                "file:size": {
+                                    "type": "int-range",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "min": 15927,
+                                    "max": 24979606
+                                },
+                                "roles": {
+                                    "type": "distinct",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 63286,
+                                            "value": [
+                                                "data"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "key_sets": {
+                                "type": "distinct",
+                                "values": [
+                                    {
+                                        "keys": [
+                                            "resolution",
+                                            "file:size",
+                                            "roles",
+                                            "description",
+                                            "eo:bands",
+                                            "type",
+                                            "file:checksum",
+                                            "href",
+                                            "file:local_path"
+                                        ],
+                                        "count_with": 63286
+                                    }
+                                ]
+                            }
+                        }
+                    },
+                    "rcGifapar": {
+                        "type": "object",
+                        "count_with": 63286,
+                        "count_without": 200177,
+                        "summary": {
+                            "count": 63286,
+                            "keys": {
+                                "href": {
+                                    "type": "mixed-value",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2021/07/29/S3B_OL_2_LFR____20210729T075340_20210729T075640_20210729T095309_0180_055_149_2880_LN1_O_NR_002.SEN3/rc_gifapar.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2021/07/29/S3B_OL_2_LFR____20210729T093439_20210729T093739_20210729T114621_0180_055_150_2880_LN1_O_NR_002.SEN3/rc_gifapar.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2021/07/29/S3A_OL_2_LFR____20210729T080901_20210729T081201_20210729T103311_0179_074_292_1440_LN1_O_NR_002.SEN3/rc_gifapar.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "https://sentinel3euwest.blob.core.windows.net/sentinel-3/OLCI/OL_2_LFR___/2021/07/29/S3B_OL_2_LFR____20210729T074740_20210729T075040_20210729T095406_0179_055_149_2520_LN1_O_NR_002.SEN3/rc_gifapar.nc"
+                                        }
+                                    ]
+                                },
+                                "type": {
+                                    "type": "distinct",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 63286,
+                                            "value": "application/x-netcdf"
+                                        }
+                                    ]
+                                },
+                                "description": {
+                                    "type": "distinct",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "string",
+                                            "count": 63286,
+                                            "value": "Rectified Reflectance"
+                                        }
+                                    ]
+                                },
+                                "resolution": {
+                                    "type": "distinct",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 63286,
+                                            "value": [
+                                                270,
+                                                294
+                                            ]
+                                        }
+                                    ]
+                                },
+                                "file:checksum": {
+                                    "type": "mixed-value",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "9cd16a35cea088e8cfdca115b302fcc2"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "df6f1414fa5d4e487283120c6412e45f"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "8bcc1646fd329fd8a0e64b14e52f8e2b"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "5e4d9c27df9f0e9d8b9f5b6bc7303ae0"
+                                        }
+                                    ]
+                                },
+                                "file:local_path": {
+                                    "type": "mixed-value",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "data_types": [
+                                        "string"
+                                    ],
+                                    "sample": [
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3B_OL_2_LFR____20210729T075340_20210729T075640_20210729T095309_0180_055_149_2880_LN1_O_NR_002.SEN3/rc_gifapar.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3B_OL_2_LFR____20210729T093439_20210729T093739_20210729T114621_0180_055_150_2880_LN1_O_NR_002.SEN3/rc_gifapar.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3A_OL_2_LFR____20210729T080901_20210729T081201_20210729T103311_0179_074_292_1440_LN1_O_NR_002.SEN3/rc_gifapar.nc"
+                                        },
+                                        {
+                                            "type": "string",
+                                            "count": 1,
+                                            "value": "S3B_OL_2_LFR____20210729T074740_20210729T075040_20210729T095406_0179_055_149_2520_LN1_O_NR_002.SEN3/rc_gifapar.nc"
+                                        }
+                                    ]
+                                },
+                                "file:size": {
+                                    "type": "int-range",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "min": 23114,
+                                    "max": 61053372
+                                },
+                                "roles": {
+                                    "type": "distinct",
+                                    "count_with": 63286,
+                                    "count_without": 0,
+                                    "values": [
+                                        {
+                                            "type": "list",
+                                            "count": 63286,
+                                            "value": [
+                                                "data"
+                                            ]
+                                        }
+                                    ]
+                                }
+                            },
+                            "key_sets": {
+                                "type": "distinct",
+                                "values": [
+                                    {
+                                        "keys": [
+                                            "resolution",
+                                            "file:size",
+                                            "roles",
+                                            "description",
+                                            "type",
+                                            "file:checksum",
+                                            "href",
+                                            "file:local_path"
+                                        ],
+                                        "count_with": 63286
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                },
+                "key_sets": {
+                    "type": "distinct",
+                    "values": [
+                        {
+                            "keys": [
+                                "ogvi",
+                                "tieGeoCoordinates",
+                                "geoCoordinates",
+                                "safe-manifest",
+                                "lqsf",
+                                "iwv",
+                                "timeCoordinates",
+                                "otci",
+                                "tieGeometries",
+                                "instrumentData",
+                                "rcOgvi",
+                                "tieMeteo"
+                            ],
+                            "count_with": 200177
+                        },
+                        {
+                            "keys": [
+                                "rcGifapar",
+                                "geoCoordinates",
+                                "tieGeoCoordinates",
+                                "safe-manifest",
+                                "lqsf",
+                                "iwv",
+                                "timeCoordinates",
+                                "otci",
+                                "tieGeometries",
+                                "instrumentData",
+                                "gifapar",
+                                "tieMeteo"
+                            ],
+                            "count_with": 63286
+                        }
+                    ]
+                }
+            }
+        },
+        "bbox": {
+            "type": "mixed-value",
+            "count_with": 263463,
+            "count_without": 0,
+            "data_types": [
+                "list"
+            ],
+            "sample": [
+                {
+                    "type": "list",
+                    "count": 1,
+                    "value": [
+                        -102.694,
+                        69.2572,
+                        -39.7646,
+                        83.6158
+                    ]
+                },
+                {
+                    "type": "list",
+                    "count": 1,
+                    "value": [
+                        -82.1986,
+                        76.6847,
+                        112.12,
+                        88.8095
+                    ]
+                },
+                {
+                    "type": "list",
+                    "count": 1,
+                    "value": [
+                        148.242,
+                        18.3364,
+                        163.439,
+                        31.2939
+                    ]
+                },
+                {
+                    "type": "list",
+                    "count": 1,
+                    "value": [
+                        -65.2935,
+                        75.7585,
+                        7.41228,
+                        85.9504
+                    ]
+                }
+            ]
+        },
+        "stac_extensions": {
+            "type": "distinct",
+            "count_with": 263463,
+            "count_without": 0,
+            "values": [
+                {
+                    "type": "list",
+                    "count": 263463,
+                    "value": [
+                        "https://stac-extensions.github.io/file/v2.1.0/schema.json",
+                        "https://stac-extensions.github.io/sat/v1.0.0/schema.json",
+                        "https://stac-extensions.github.io/eo/v1.0.0/schema.json"
+                    ]
+                }
+            ]
+        }
+    },
+    "key_sets": {
+        "type": "distinct",
+        "values": [
+            {
+                "keys": [
+                    "links",
+                    "properties",
+                    "stac_extensions",
+                    "id",
+                    "bbox",
+                    "geometry",
+                    "type",
+                    "assets",
+                    "stac_version"
+                ],
+                "count_with": 263463
+            }
+        ]
+    }
+}

--- a/pctasks/core/tests/utils/test_summary.py
+++ b/pctasks/core/tests/utils/test_summary.py
@@ -333,3 +333,56 @@ def test_several_asset_descriptions():
             values=[StringValueCount(value=f"Image {i}", count=5) for i in range(20)],
         ).dict()
     )
+
+
+import pathlib
+
+import pytest
+
+from pctasks.core.utils.summary import ObjectSummary, make_collection
+
+
+@pytest.fixture
+def s3_frp_summary():
+    p = HERE.parent.parent.parent.parent.joinpath(
+        "datasets/sentinel-3/summaries/sentinel-3-olci-lfr-l2-netcdf.json"
+    )
+    return ObjectSummary.parse_file(p)
+
+
+def test_make_collection(s3_frp_summary):
+    result = make_collection(s3_frp_summary, "id")
+
+    expected = {
+        "stac_version": "1.0.0",
+        "id": "id",
+        "type": "Collection",
+        "description": "{{ collection.description }}",
+        "keywords": [],
+        "stac_extensions": [],
+        "summaries": {
+            "platform": ["Sentinel-3A", "Sentinel-3B"],
+            "constellation": ["Sentinel-3"],
+            "instruments": [["OLCI"]],
+            # "sat:platform_international_designator": ["2016-011A", "2018-039A"],
+            # "sat:orbit_state": ["descending", "ascending"],
+            # "s3:productType": ["OL_2_LFR___"],
+            # "s3:gsd": [300],
+            # "s3:salineWaterPixels_percentage": [0, 100],
+            # "s3:coastalPixels_percentage": [0, 100],
+            # "s3:freshInlandWaterPixels_percentage": [0, 100],
+            # "s3:tidalRegionPixels_percentage": [0, 100],
+            # "s3:landPixels_percentage": [0, 100],
+            # "s3:invalidPixels_percentage": [0, 100],
+            # "s3:cosmeticPixels_percentage": [0, 100],
+            # "s3:duplicatedPixels_percentage": [0, 100],
+            # "s3:saturatedPixels_percentage": [0, 100],
+            # "s3:dubiousSamples_percentage": [0, 100],
+            # "s5p:collection_identifier": [
+            #     "01",
+            #     "02",
+            #     "03"
+            # ]
+        },
+    }
+    assert result == expected

--- a/pctasks/core/tests/utils/test_summary.py
+++ b/pctasks/core/tests/utils/test_summary.py
@@ -3,6 +3,8 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict, List, cast
 
+import pytest
+
 from pctasks.core.utils.summary import (
     DistinctKeySets,
     DistinctValueSummary,
@@ -16,10 +18,12 @@ from pctasks.core.utils.summary import (
     StringValueCount,
     SummarySettings,
     ValueTypes,
+    make_collection,
 )
 
 HERE = Path(__file__).parent
 ITEMS_DIR = Path(__file__).parent.parent / "data-files" / "items"
+SUMMARIES_DIR = HERE.parent / "data-files" / "summaries"
 
 
 def test_asset_counts():
@@ -335,54 +339,219 @@ def test_several_asset_descriptions():
     )
 
 
-import pathlib
-
-import pytest
-
-from pctasks.core.utils.summary import ObjectSummary, make_collection
-
-
 @pytest.fixture
 def s3_frp_summary():
-    p = HERE.parent.parent.parent.parent.joinpath(
-        "datasets/sentinel-3/summaries/sentinel-3-olci-lfr-l2-netcdf.json"
-    )
+    p = SUMMARIES_DIR.joinpath("sentinel-3-olci-lfr-l2-netcdf.json")
     return ObjectSummary.parse_file(p)
 
 
 def test_make_collection(s3_frp_summary):
-    result = make_collection(s3_frp_summary, "id")
+    percentages = {
+        "s3:coastalPixels_percentage",
+        "s3:salineWaterPixels_percentage",
+        "s3:cosmeticPixels_percentage",
+        "s3:dubiousSamples_percentage",
+        "s3:freshInlandWaterPixels_percentage",
+        "s3:invalidPixels_percentage",
+        "s3:landPixels_percentage",
+        "s3:duplicatedPixels_percentage",
+        "s3:tidalRegionPixels_percentage",
+        "s3:saturatedPixels_percentage",
+        "sat:absolute_orbit",
+        "sat:relative_orbit",
+        "eo:cloud_cover",
+    }
+    result = make_collection(
+        s3_frp_summary,
+        "id",
+        title="Sentinel 3",
+        extra_fields={
+            "msft:region": "westeurope",
+        },
+        extra_summary_exclude={
+            "s3:shape",
+            "s3:gsd",
+            "s3:productType",
+            "sat:orbit_state",
+            "s3:mode",
+            "providers",
+        }
+        | percentages,
+        item_assets_exclude="resolution",
+    )
 
     expected = {
         "stac_version": "1.0.0",
         "id": "id",
         "type": "Collection",
         "description": "{{ collection.description }}",
+        "title": "Sentinel 3",
         "keywords": [],
         "stac_extensions": [],
+        "links": [],
+        "msft:region": "westeurope",
         "summaries": {
             "platform": ["Sentinel-3A", "Sentinel-3B"],
             "constellation": ["Sentinel-3"],
             "instruments": [["OLCI"]],
-            # "sat:platform_international_designator": ["2016-011A", "2018-039A"],
-            # "sat:orbit_state": ["descending", "ascending"],
-            # "s3:productType": ["OL_2_LFR___"],
-            # "s3:gsd": [300],
-            # "s3:salineWaterPixels_percentage": [0, 100],
-            # "s3:coastalPixels_percentage": [0, 100],
-            # "s3:freshInlandWaterPixels_percentage": [0, 100],
-            # "s3:tidalRegionPixels_percentage": [0, 100],
-            # "s3:landPixels_percentage": [0, 100],
-            # "s3:invalidPixels_percentage": [0, 100],
-            # "s3:cosmeticPixels_percentage": [0, 100],
-            # "s3:duplicatedPixels_percentage": [0, 100],
-            # "s3:saturatedPixels_percentage": [0, 100],
-            # "s3:dubiousSamples_percentage": [0, 100],
-            # "s5p:collection_identifier": [
-            #     "01",
-            #     "02",
-            #     "03"
-            # ]
+            "sat:platform_international_designator": ["2016-011A", "2018-039A"],
+        },
+        "item_assets": {
+            "safe-manifest": {"type": "application/xml", "roles": ["metadata"]},
+            "ogvi": {
+                "description": "OLCI global Vegetal Index",
+                "type": "application/x-netcdf",
+                "roles": ["data"],
+                "eo:bands": [
+                    {
+                        "name": "Oa03",
+                        "description": "Band 3 - Chlorophyll absorption maximum, biogeochemistry, vegetation",
+                        "center_wavelength": 442.5,
+                        "band_width": 10,
+                    },
+                    {
+                        "name": "Oa10",
+                        "description": "Band 10 - Chlorophyll fluorescence peak, red edge",
+                        "center_wavelength": 681.25,
+                        "band_width": 7.5,
+                    },
+                    {
+                        "name": "Oa17",
+                        "description": "Band 17 - Atmospheric / aerosol correction, clouds, pixel co-registration",
+                        "center_wavelength": 865,
+                        "band_width": 20,
+                    },
+                ],
+            },
+            "otci": {
+                "description": "OLCI Terrestrial Chlorophyll Index",
+                "type": "application/x-netcdf",
+                "roles": ["data"],
+                "eo:bands": [
+                    {
+                        "name": "Oa10",
+                        "description": "Band 10 - Chlorophyll fluorescence peak, red edge",
+                        "center_wavelength": 681.25,
+                        "band_width": 7.5,
+                    },
+                    {
+                        "name": "Oa11",
+                        "description": "Band 11 - Chlorophyll fluorescence baseline, red edge transition",
+                        "center_wavelength": 708.75,
+                        "band_width": 10,
+                    },
+                    {
+                        "name": "Oa12",
+                        "description": "Band 12 - O2 absorption / clouds, vegetation",
+                        "center_wavelength": 753.75,
+                        "band_width": 7.5,
+                    },
+                ],
+            },
+            "iwv": {
+                "description": "Integrated water vapour column",
+                "type": "application/x-netcdf",
+                "roles": ["data"],
+                "eo:bands": [
+                    {
+                        "name": "Oa18",
+                        "description": "Band 18 - Water vapour absorption reference. Common reference band with SLSTR. Vegetation monitoring",
+                        "center_wavelength": 885,
+                        "band_width": 10,
+                    },
+                    {
+                        "name": "Oa19",
+                        "description": "Band 19 - Water vapour absorption, vegetation monitoring (maximum REFLECTANCE)",
+                        "center_wavelength": 900,
+                        "band_width": 10,
+                    },
+                ],
+            },
+            "rcOgvi": {
+                "description": "Rectified Reflectance",
+                "type": "application/x-netcdf",
+                "roles": ["data"],
+                "eo:bands": [
+                    {
+                        "name": "Oa10",
+                        "description": "Band 10 - Chlorophyll fluorescence peak, red edge",
+                        "center_wavelength": 681.25,
+                        "band_width": 7.5,
+                    },
+                    {
+                        "name": "Oa17",
+                        "description": "Band 17 - Atmospheric / aerosol correction, clouds, pixel co-registration",
+                        "center_wavelength": 865,
+                        "band_width": 20,
+                    },
+                ],
+            },
+            "lqsf": {
+                "description": "Land Quality and Science Flags",
+                "type": "application/x-netcdf",
+                "roles": ["data"],
+            },
+            "timeCoordinates": {
+                "description": "Time Coordinates Annotations",
+                "type": "application/x-netcdf",
+                "roles": ["data"],
+            },
+            "geoCoordinates": {
+                "description": "Geo Coordinates Annotations",
+                "type": "application/x-netcdf",
+                "roles": ["data"],
+            },
+            "tieGeoCoordinates": {
+                "description": "Tie-Point Geo Coordinate Annotations",
+                "type": "application/x-netcdf",
+                "roles": ["data"],
+            },
+            "tieGeometries": {
+                "description": "Tie-Point Geometries Annotations",
+                "type": "application/x-netcdf",
+                "roles": ["data"],
+            },
+            "tieMeteo": {
+                "description": "Tie-Point Meteo Annotations",
+                "type": "application/x-netcdf",
+                "roles": ["data"],
+            },
+            "instrumentData": {
+                "description": "Instrument Annotation",
+                "type": "application/x-netcdf",
+                "roles": ["data"],
+            },
+            "gifapar": {
+                "description": "Green Instantaneous FAPAR",
+                "type": "application/x-netcdf",
+                "roles": ["data"],
+                "eo:bands": [
+                    {
+                        "name": "Oa03",
+                        "description": "Band 3 - Chlorophyll absorption maximum, biogeochemistry, vegetation",
+                        "center_wavelength": 442.5,
+                        "band_width": 10,
+                    },
+                    {
+                        "name": "Oa10",
+                        "description": "Band 10 - Chlorophyll fluorescence peak, red edge",
+                        "center_wavelength": 681.25,
+                        "band_width": 7.5,
+                    },
+                    {
+                        "name": "Oa17",
+                        "description": "Band 17 - Atmospheric / aerosol correction, clouds, pixel co-registration",
+                        "center_wavelength": 865,
+                        "band_width": 20,
+                    },
+                ],
+            },
+            "rcGifapar": {
+                "description": "Rectified Reflectance",
+                "type": "application/x-netcdf",
+                "roles": ["data"],
+            },
         },
     }
     assert result == expected
+    assert 0


### PR DESCRIPTION
## Description

Adds a new method for turning an `ObjectSummary`, from analyzing a batch of STAC items, into (the start of) a STAC collection.

```python
    percentages = {
        "s3:coastalPixels_percentage",
        "s3:salineWaterPixels_percentage",
        "s3:cosmeticPixels_percentage",
        "s3:dubiousSamples_percentage",
        "s3:freshInlandWaterPixels_percentage",
        "s3:invalidPixels_percentage",
        "s3:landPixels_percentage",
        "s3:duplicatedPixels_percentage",
        "s3:tidalRegionPixels_percentage",
        "s3:saturatedPixels_percentage",
        "sat:absolute_orbit",
        "sat:relative_orbit",
        "eo:cloud_cover",
    }
    result = make_collection(
        s3_frp_summary,
        "id",
        title="Sentinel 3",
        extra_fields={
            "msft:region": "westeurope",
        },
        extra_summary_exclude={
            "s3:shape",
            "s3:gsd",
            "s3:productType",
            "sat:orbit_state",
            "s3:mode",
            "providers",
        }
        | percentages,
        item_assets_exclude="resolution",
    )
```

Which gives

<details>

```json
{'stac_version': '1.0.0',
 'id': 'id',
 'type': 'Collection',
 'description': '{{ collection.description }}',
 'links': [],
 'keywords': [],
 'stac_extensions': [],
 'summaries': {'sat:platform_international_designator': ['2016-011A',
   '2018-039A'],
  'instruments': [['OLCI']],
  'platform': ['Sentinel-3A', 'Sentinel-3B'],
  'constellation': ['Sentinel-3']},
 'item_assets': {'safe-manifest': {'type': 'application/xml',
   'roles': ['metadata']},
  'ogvi': {'type': 'application/x-netcdf',
   'description': 'OLCI global Vegetal Index',
   'roles': ['data'],
   'eo:bands': [{'name': 'Oa03',
     'description': 'Band 3 - Chlorophyll absorption maximum, biogeochemistry, vegetation',
     'center_wavelength': 442.5,
     'band_width': 10},
    {'name': 'Oa10',
     'description': 'Band 10 - Chlorophyll fluorescence peak, red edge',
     'center_wavelength': 681.25,
     'band_width': 7.5},
    {'name': 'Oa17',
     'description': 'Band 17 - Atmospheric / aerosol correction, clouds, pixel co-registration',
     'center_wavelength': 865,
     'band_width': 20}]},
  'otci': {'type': 'application/x-netcdf',
   'description': 'OLCI Terrestrial Chlorophyll Index',
   'roles': ['data'],
   'eo:bands': [{'name': 'Oa10',
     'description': 'Band 10 - Chlorophyll fluorescence peak, red edge',
     'center_wavelength': 681.25,
     'band_width': 7.5},
    {'name': 'Oa11',
     'description': 'Band 11 - Chlorophyll fluorescence baseline, red edge transition',
     'center_wavelength': 708.75,
     'band_width': 10},
    {'name': 'Oa12',
     'description': 'Band 12 - O2 absorption / clouds, vegetation',
     'center_wavelength': 753.75,
     'band_width': 7.5}]},
  'iwv': {'type': 'application/x-netcdf',
   'description': 'Integrated water vapour column',
   'roles': ['data'],
   'eo:bands': [{'name': 'Oa18',
     'description': 'Band 18 - Water vapour absorption reference. Common reference band with SLSTR. Vegetation monitoring',
     'center_wavelength': 885,
     'band_width': 10},
    {'name': 'Oa19',
     'description': 'Band 19 - Water vapour absorption, vegetation monitoring (maximum REFLECTANCE)',
     'center_wavelength': 900,
     'band_width': 10}]},
  'rcOgvi': {'type': 'application/x-netcdf',
   'description': 'Rectified Reflectance',
   'roles': ['data'],
   'eo:bands': [{'name': 'Oa10',
     'description': 'Band 10 - Chlorophyll fluorescence peak, red edge',
     'center_wavelength': 681.25,
     'band_width': 7.5},
    {'name': 'Oa17',
     'description': 'Band 17 - Atmospheric / aerosol correction, clouds, pixel co-registration',
     'center_wavelength': 865,
     'band_width': 20}]},
  'lqsf': {'type': 'application/x-netcdf',
   'description': 'Land Quality and Science Flags',
   'roles': ['data']},
  'timeCoordinates': {'type': 'application/x-netcdf',
   'description': 'Time Coordinates Annotations',
   'roles': ['data']},
  'geoCoordinates': {'type': 'application/x-netcdf',
   'description': 'Geo Coordinates Annotations',
   'roles': ['data']},
  'tieGeoCoordinates': {'type': 'application/x-netcdf',
   'description': 'Tie-Point Geo Coordinate Annotations',
   'roles': ['data']},
  'tieGeometries': {'type': 'application/x-netcdf',
   'description': 'Tie-Point Geometries Annotations',
   'roles': ['data']},
  'tieMeteo': {'type': 'application/x-netcdf',
   'description': 'Tie-Point Meteo Annotations',
   'roles': ['data']},
  'instrumentData': {'type': 'application/x-netcdf',
   'description': 'Instrument Annotation',
   'roles': ['data']},
  'gifapar': {'type': 'application/x-netcdf',
   'description': 'Green Instantaneous FAPAR',
   'roles': ['data'],
   'eo:bands': [{'name': 'Oa03',
     'description': 'Band 3 - Chlorophyll absorption maximum, biogeochemistry, vegetation',
     'center_wavelength': 442.5,
     'band_width': 10},
    {'name': 'Oa10',
     'description': 'Band 10 - Chlorophyll fluorescence peak, red edge',
     'center_wavelength': 681.25,
     'band_width': 7.5},
    {'name': 'Oa17',
     'description': 'Band 17 - Atmospheric / aerosol correction, clouds, pixel co-registration',
     'center_wavelength': 865,
     'band_width': 20}]},
  'rcGifapar': {'type': 'application/x-netcdf',
   'description': 'Rectified Reflectance',
   'roles': ['data']}},
 'title': 'Sentinel 3',
 'msft:region': 'westeurope'}
```

</details>
