### PR TITLE
[packaging]: Fixed install_requires

### DIFF
--- a/pctasks/core/setup.py
+++ b/pctasks/core/setup.py
@@ -6,20 +6,20 @@ with open("README.md") as f:
     desc = f.read()
 
 install_requires = [
-    "azure-identity==1.*",
+    "azure-identity>=1.0.0,<2",
     "azure-storage-blob==12.9",  # Issues with 12.11 generating sas from account keys
     # https://github.com/microsoft/planetary-computer-tasks/issues/136
     "azure-storage-queue>=12.6.0",
-    "azure-data-tables==12.*",
-    "azure-cosmos==4.3.*",
+    "azure-data-tables>=12.0.0,<13",
+    "azure-cosmos>=4.3.0,<4.4.0",
     "pydantic>=1.9,<2.0.0",
-    "orjson==3.*",
+    "orjson>=3.0.0,<4",
     "strictyaml>=1.6",
-    "stac-validator>=3.1.*",
+    "stac-validator>=3.1.0",
     "opencensus-ext-azure==1.1.0",
     "opencensus-ext-logging==0.1.1",
     "pyyaml>=5.3",
-    "aiohttp==3.8.*",
+    "aiohttp>=3.8.0,<3.9",
     "planetary-computer>=0.4.0",
 ]
 

--- a/pctasks/dev/setup.py
+++ b/pctasks/dev/setup.py
@@ -13,7 +13,7 @@ install_requires = [
     "pctasks.cli>=0.1.0",
 ]
 
-extra_reqs = {"server": ["fastapi==0.70.*", "uvicorn[standard]==0.16.*"]}
+extra_reqs = {"server": ["fastapi==0.78.0,<0.79", "uvicorn[standard]>=0.12.0,<0.16.0"]}
 
 
 setup(

--- a/pctasks/ingest_task/setup.py
+++ b/pctasks/ingest_task/setup.py
@@ -9,7 +9,7 @@ install_requires = [
     "pctasks.task>=0.1.0",
     "pctasks.ingest>=0.1.0",
     "pypgstac[psycopg]==0.7.3",
-    "pystac==1.*",
+    "pystac>=1.0.0,<2",
     "smart-open==4.2.0",
     "orjson>=3.5.2",
     "python-dateutil==2.8.2",

--- a/pctasks/run/setup.py
+++ b/pctasks/run/setup.py
@@ -9,10 +9,10 @@ install_requires = [
     "pctasks.core>=0.1.0",
     "pctasks.task>=0.1.0",
     "pctasks.client>=0.1.0",
-    "azure-batch==11.*",
-    "azure-keyvault-secrets==4.*",
-    "argo-workflows==6.3.*",
-    "networkx==2.*"
+    "azure-batch>=11.0.0,<12",
+    "azure-keyvault-secrets>=4.0.0,<5",
+    "argo-workflows>=6.3.0,<6.4",
+    "networkx>=2.0.0,<3"
 ]
 
 extra_reqs = {

--- a/pctasks/server/setup.py
+++ b/pctasks/server/setup.py
@@ -8,7 +8,7 @@ with open("README.md") as f:
 install_requires = [
     "pctasks.core>=0.1.0",
     "pctasks.run>=0.1.0",
-    "fastapi==0.78.*",
+    "fastapi==0.78.0,<0.79",
     "python-multipart==0.0.5"
 ]
 


### PR DESCRIPTION
Various packages included invalid requirements like

    ">=3.1.*".

I've replaced those with the equivalent expansions like

    >=3.1.0,<3.2

Note: I don't think that pctasks should be setting upper bounds *anywhere* in its requirements (and so no exact pins. Lower bounds are fine). Instead, specific deployments of pctasks should be pinning their requirements.

Fixes the build failure in https://github.com/microsoft/planetary-computer-tasks/actions/runs/4720818604/jobs/8373333525#step:5:7874.