### PR TITLE
[goes-glm]: Bump container image

### DIFF
--- a/datasets/goes/goes-glm/dataset.yaml
+++ b/datasets/goes/goes-glm/dataset.yaml
@@ -1,5 +1,5 @@
 id: goes_glm
-image: ${{ args.registry }}/pctasks-goes-glm:2023.2.23.0
+image: ${{ args.registry }}/pctasks-goes-glm:2023.4.17.0
 
 args:
 - registry
@@ -28,15 +28,16 @@ collections:
           splits:
             - prefix: GLM-L2-LCFA/
               depth: 2
-      - uri: blob://goeseuwest/noaa-goes17/
-        token: ${{ pc.get_token(goeseuwest, noaa-goes17) }}
-        chunks:
-          options:
-            ends_with: .nc
-            chunk_length: 50000
-          splits:
-            - prefix: GLM-L2-LCFA/
-              depth: 2
+      # GOES-17 is just parked now.
+      # - uri: blob://goeseuwest/noaa-goes17/
+      #   token: ${{ pc.get_token(goeseuwest, noaa-goes17) }}
+      #   chunks:
+      #     options:
+      #       ends_with: .nc
+      #       chunk_length: 50000
+      #     splits:
+      #       - prefix: GLM-L2-LCFA/
+      #         depth: 2
 
       - uri: blob://goeseuwest/noaa-goes18/
         token: ${{ pc.get_token(goeseuwest, noaa-goes18) }}


### PR DESCRIPTION
This bumps the version of pctasks in the goes-glm container image, to include the fixes from #175.

It also removes the goes-17 container, since that's not operational anymore.