### PR TITLE
[goes-glm]: Try to fix with socket timeout

### DIFF
--- a/datasets/goes/goes-glm/dataset.yaml
+++ b/datasets/goes/goes-glm/dataset.yaml
@@ -1,5 +1,5 @@
 id: goes_glm
-image: ${{ args.registry }}/pctasks-goes-glm:2023.4.17.0
+image: ${{ args.registry }}/pctasks-goes-glm:2023.4.24.0
 
 args:
 - registry

--- a/datasets/goes/goes-glm/goes_glm.py
+++ b/datasets/goes/goes-glm/goes_glm.py
@@ -1,3 +1,4 @@
+import socket
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import List, Union
@@ -24,6 +25,11 @@ class GoesGlmCollection(Collection):
     def create_item(
         cls, asset_uri: str, storage_factory: StorageFactory
     ) -> Union[List[pystac.Item], WaitTaskResult]:
+        # Last-ditch attempt to enforce timeouts in the socket / ssl code
+        timeout = socket.getdefaulttimeout()
+        if timeout is None:
+            socket.setdefaulttimeout(60)
+        
         nc_storage, nc_asset_path = storage_factory.get_storage_for_file(asset_uri)
 
         if isinstance(nc_storage, pctasks.core.storage.blob.BlobStorage):

--- a/datasets/goes/goes-glm/workflows/goes-glm-update.yaml
+++ b/datasets/goes/goes-glm/workflows/goes-glm-update.yaml
@@ -14,7 +14,7 @@ jobs:
     id: create-splits
     tasks:
     - id: create-splits
-      image: ${{ args.registry }}/pctasks-goes-glm:2023.4.17.0
+      image: ${{ args.registry }}/pctasks-goes-glm:2023.4.24.0
       code:
         src: datasets/goes/goes-glm/goes_glm.py
       task: goes_glm:GoesGlmCollection.create_splits_task
@@ -53,7 +53,7 @@ jobs:
     id: create-chunks
     tasks:
     - id: create-chunks
-      image: ${{ args.registry }}/pctasks-goes-glm:2023.4.17.0
+      image: ${{ args.registry }}/pctasks-goes-glm:2023.4.24.0
       code:
         src: datasets/goes/goes-glm/goes_glm.py
       task: pctasks.dataset.chunks.task:create_chunks_task
@@ -74,7 +74,7 @@ jobs:
     id: process-chunk
     tasks:
     - id: create-items
-      image: ${{ args.registry }}/pctasks-goes-glm:2023.4.17.0
+      image: ${{ args.registry }}/pctasks-goes-glm:2023.4.24.0
       code:
         src: datasets/goes/goes-glm/goes_glm.py
       task: goes_glm:GoesGlmCollection.create_items_task


### PR DESCRIPTION
In a recent run, we experience the hanging goes-glm task again. Here's the backtrace from py-spy on the hanging process.

```
Thread 1 (active): "MainThread"
    read (ssl.py:1134)
    recv_into (ssl.py:1278)
    readinto (socket.py:706)
    read (http/client.py:466)
    _fp_read (urllib3/response.py:533)
    read (urllib3/response.py:567)
    stream (urllib3/response.py:628)
    generate (requests/models.py:816)
    __next__ (core/pipeline/transport/_requests_basic.py:173)
    process_content (blob/_download.py:52)
    _initial_request (blob/_download.py:435)
    __init__ (blob/_download.py:349)
    download_blob (blob/_blob_client.py:848)
    wrapper_use_tracer (core/tracing/decorator.py:76)
    <lambda> (core/storage/blob.py:514)
    with_backoff (core/utils/backoff.py:142)
    download_file (core/storage/blob.py:513)
    create_item (goes_glm.py:38)
    create_items (dataset/items/task.py:117)
    run (dataset/items/task.py:153)
    parse_and_run (task/task.py:53)
    run_task (task/run.py:138)
    run_cmd (task/_cli.py:32)
    run_cmd (task/cli.py:50)
    new_func (click/decorators.py:26)
    invoke (click/core.py:760)
    invoke (click/core.py:1404)
    invoke (click/core.py:1657)
    invoke (click/core.py:1657)
    main (click/core.py:1055)
    __call__ (click/core.py:1130)
    cli (cli/cli.py:140)
    <module> (pctasks:8)
Thread 13 (idle): "fsspecIO"
    select (selectors.py:468)
    _run_once (asyncio/base_events.py:1884)
    run_forever (asyncio/base_events.py:607)
    run (threading.py:975)
    _bootstrap_inner (threading.py:1038)
    _bootstrap (threading.py:995)
Thread 14 (active): "asyncio_0"
    _worker (concurrent/futures/thread.py:81)
    run (threading.py:975)
    _bootstrap_inner (threading.py:1038)
    _bootstrap (threading.py:995)

```

I think we only care about the `MainThread`. Setting the `timeout_seconds` on the `download_blob` request was apparently not sufficient. I don't know if setting the default socket timeout is sufficient, but it's worth a shot.