### PR TITLE
[dataset] Gracefully handle all-None Chunkset

### DIFF
--- a/pctasks/dataset/pctasks/dataset/chunks/chunkset.py
+++ b/pctasks/dataset/pctasks/dataset/chunks/chunkset.py
@@ -118,6 +118,10 @@ class ChunkSet:
                 self._all_storage.write_bytes(
                     chunk_id, b"\n".join(cast(List[bytes], lines))
                 )
+        else:
+            # We'll just write an empty file to ensure that the ingest stage
+            # doesn't fail.
+            self._all_storage.write_bytes(chunk_id, b"")
 
     def mark_success(self, chunk_id: str) -> None:
         """Marks a chunk file as succeeded"""

--- a/pctasks/dataset/tests/chunks/test_task.py
+++ b/pctasks/dataset/tests/chunks/test_task.py
@@ -6,6 +6,8 @@ from planetary_computer.sas import get_token
 
 from pctasks.core.models.task import CompletedTaskResult
 from pctasks.core.models.tokens import ContainerTokens, StorageAccountTokens
+from pctasks.core.storage import StorageFactory
+from pctasks.dataset.chunks.chunkset import ChunkSet
 from pctasks.dataset.chunks.constants import ALL_CHUNK_PREFIX
 from pctasks.dataset.chunks.models import ChunksOutput
 from pctasks.dataset.chunks.task import CreateChunksInput, create_chunks_task
@@ -205,3 +207,14 @@ def test_task_list_folders():
                 for line in f:
                     assert Path(line).exists
                     assert Path(line.strip()).is_dir()
+
+
+def test_empty_chunkset(tmp_path):
+    storage_factory = StorageFactory()
+    storage = storage_factory.get_storage(f"{tmp_path}/chunksets/")
+
+    items_chunk_id = "chunk0"
+    chunkset = ChunkSet(storage)
+    chunkset.write_chunk(items_chunk_id, [])
+
+    assert storage.file_exists(f"all/{items_chunk_id}")


### PR DESCRIPTION
This updates the behavior of the create items task when the user-provided `create_items` function returns `None` for every asset in the chunkfile.

Previously, we would only write an ndjson file to storage if there were any valid items returned by `create_items`. If the `results` were empty (no items were returned for the entire chunkfile) then we'd skip writing the output file.

This was incompatible with the `ingest-items` task, which assumes the file exists when it comes to reading. It would try to read the file and error, causing the run to fail.

We have (at least) two choices on how to reconcile this:

1. Always write an ndjson file in create items, even if it's empty.
2. Ignore missing files in ingest-items.

Option 1 feels much safer. Presumably the user knows what they're doing when they return `None` from their function. By the time we get to `ingest-items`, we have no idea why a file might be missing.