### PR TITLE
Updated ms-buildings

### DIFF
--- a/datasets/ms-buildings/collection/description.md
+++ b/datasets/ms-buildings/collection/description.md
@@ -17,10 +17,36 @@ The building extraction is done in two stages:
 
 ![Polygonization](https://github.com/microsoft/GlobalMLBuildingFootprints/raw/main/images/polygonization.jpg)
 
-## STAC metadata
-
-This STAC collection has one STAC item per region. The `msbuildings:region` property can be used to filter items to a specific region.
-
 ## Data assets
 
-The building footprints are provided as a set of [geoparquet](https://github.com/opengeospatial/geoparquet) datasets. The data are partitioned at multiple levels. There is one [Parquet dataset](https://arrow.apache.org/docs/python/parquet.html#partitioned-datasets-multiple-files) per region. Regions are partitioned into many parquet files so that each file fits comfortably in memory.
+The building footprints are provided as a set of [geoparquet](https://github.com/opengeospatial/geoparquet) datasets in [Delta][delta] table format.
+The data are partitioned by
+
+1. Region
+2. quadkey at [Bing Map Tiles][tiles] level 9
+
+Each `(Region, quadkey)` pair will have one or more geoparquet files, depending on the density of the of the buildings in that area.
+
+Note that older items in this dataset are *not* spatially partitioned. We recommend using data with a processing date
+of 2023-04-25 or newer. This processing date is part of the URL for each parquet file and is captured in the STAC metadata
+for each item (see below).
+
+## Delta Format
+
+The collection-level asset under the `delta` key gives you the fsspec-style URL
+to the Delta table. This can be used to efficiently query for matching partitions
+by `Region` and `quadkey`. See the notebook for an example using Python.
+
+## STAC metadata
+
+This STAC collection has one STAC item per region. The `msbuildings:region`
+property can be used to filter items to a specific region, and the `msbuildings:quadkey`
+property can be used to filter items to a specific quadkey (though you can also search
+by the `geometry`).
+
+Note that older STAC items are not spatially partitioned. We recommend filtering on
+items with an `msbuildings:processing-date` of `2023-04-25` or newer. See the collection
+summary for `msbuildings:processing-date` for a list of valid values.
+
+[delta]: https://delta.io/
+[tiles]: https://learn.microsoft.com/en-us/bingmaps/articles/bing-maps-tile-system

--- a/datasets/ms-buildings/collection/template.json
+++ b/datasets/ms-buildings/collection/template.json
@@ -66,8 +66,14 @@
     "Buildings",
     "geoparquet",
     "Microsoft",
-    "Footprint"
+    "Footprint",
+    "Delta"
   ],
+  "summaries": {
+    "msbuildings:processing-date": [
+      "2023-04-25"
+    ]
+  },
   "providers": [
     {
       "name": "Microsoft",
@@ -84,6 +90,14 @@
       "href": "https://ai4edatasetspublicassets.blob.core.windows.net/assets/pc_thumbnails/msbuildings-thumbnail.png",
       "type": "image/png",
       "title": "Thumbnail"
+    },
+    "delta": {
+      "href": "az://footprints/delta/2023-04-25/ml-buildings.parquet/",
+      "title": "Delta table",
+      "description": "Delta table with latest buildings footprints partitioned by Region and quadkey.",
+      "table:storage_options": {
+        "account_name": "bingmlbuildings"
+      }
     }
   }
 }

--- a/datasets/ms-buildings/dataset.yaml
+++ b/datasets/ms-buildings/dataset.yaml
@@ -1,5 +1,5 @@
 id: ms-buildings
-image: ${{ args.registry }}/pctasks-msbuildings:2023.5.2.3
+image: ${{ args.registry }}/pctasks-msbuildings:2023.5.3.0
 
 args:
 - registry

--- a/datasets/ms-buildings/dataset.yaml
+++ b/datasets/ms-buildings/dataset.yaml
@@ -1,8 +1,14 @@
 id: ms-buildings
-image: ${{ args.registry }}/pctasks-task-base:latest
+image: ${{ args.registry }}/pctasks-msbuildings:2023.5.2.3
 
 args:
 - registry
+# Prefix is a date like prefix=delta/2023-04-25/ml-buildings.parquet/
+- prefix
+
+code:
+  src: ${{ local.path(./ms_buildings.py) }}
+  requirements: ${{ local.path(./requirements.txt) }}
 
 environment:
   AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
@@ -12,14 +18,19 @@ environment:
 collections:
   - id: ms-buildings
     template: ${{ local.path(./collection) }}
-    class: pctasks.dataset.collection:PremadeItemCollection
+    class: ms_buildings:MSBuildingsCollection
+
     asset_storage:
-      # the STAC items
-      - uri: blob://bingmlbuildings/msbuildings-stac
+      # Targeting chunk lines like the following:
+      #   global/2023-04-25/ml-buildings.parquet/RegionName=Abyei/quadkey=122321003
+      - uri: blob://bingmlbuildings/footprints/
         chunks:
           options:
-            chunk_length: 3000
-            extensions:
-              - ".json"
+            name_starts_with: ${{args.prefix}}
+            list_folders: true
+            limit: 10
+            min_depth: 3
+            max_depth: 4
+            chunk_length: 500
     chunk_storage:
-      uri: blob://bingmlbuildings/msbuildings-etl-data/chunks
+      uri: blob://bingmlbuildings/msbuildings-etl-data/msbuildings/

--- a/datasets/ms-buildings/ms_buildings.py
+++ b/datasets/ms-buildings/ms_buildings.py
@@ -1,0 +1,48 @@
+from typing import List, Union
+
+from stactools.msbuildings import stac
+import pystac
+
+from pctasks.core.models.task import WaitTaskResult
+from pctasks.core.storage import StorageFactory
+from pctasks.dataset.collection import Collection
+
+
+class MSBuildingsCollection(Collection):
+    @classmethod
+    def create_item(
+        cls, asset_uri: str, storage_factory: StorageFactory
+    ) -> Union[List[pystac.Item], WaitTaskResult]:
+        import azure.identity.aio
+
+        _, path = storage_factory.get_storage_for_file(asset_uri)
+
+        if "quadkey" not in path:
+            # The listing isn't quite right. Have to return `[]` for
+            # the "Region" folders.
+            return []
+
+        item = stac.create_item(
+            f"abfs://footprints/{path}",
+            asset_extra_fields={
+                "table:storage_options": {"account_name": "bingmlbuildings"}
+            },
+            storage_options={
+                "account_name": "bingmlbuildings",
+                "credential": azure.identity.aio.DefaultAzureCredential(),
+            },
+        )
+        item.collection_id = "ms-buildings"
+        return [item]
+
+
+if __name__ == "__main__":
+    [item] = MSBuildingsCollection.create_item(
+        "blob://bingmlbuildings/footprints/delta/2023-04-25/ml-buildings.parquet/RegionName=Abyei/quadkey=122321003",
+        StorageFactory(),
+    )
+
+    assert item.assets["data"].extra_fields["table:storage_options"] == {
+        "account_name": "bingmlbuildings"
+    }
+    assert item.properties["msbuildings:processing-date"] == "2023-04-25"

--- a/datasets/ms-buildings/requirements.txt
+++ b/datasets/ms-buildings/requirements.txt
@@ -1,0 +1,2 @@
+git+https://github.com/stactools-packages/msbuildings.git@4a94cb7aef8c5929ebfa3f779a68a05c268b6f72
+adlfs

--- a/datasets/ms-buildings/requirements.txt
+++ b/datasets/ms-buildings/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/stactools-packages/msbuildings.git@4a94cb7aef8c5929ebfa3f779a68a05c268b6f72
+git+https://github.com/stactools-packages/msbuildings.git@e7731afde6a1a767827c2c98b12cb414c08add6c
 adlfs

--- a/docs/user_guide/chunking.md
+++ b/docs/user_guide/chunking.md
@@ -36,6 +36,7 @@ chunks:
     ends_with: manifest.xml  # Only include asset URIs that end with this string.
     matches: .*/scene-\d+.tif  # Only include asset URIs that match this regex."""
     max_depth: 10  # Maximum number of directories to descend into.
+    min_depth: 10  # Minimum number of directories to descend into. Useful for listing a subfolder.
     list_folders: true  # Whether to list files (the default) or folders instead of files.
     chunk_file_name: uri-list  # Chunk file name.
     chunk_extension: .csv  # Extensions of the chunk file names.

--- a/pctasks/dataset/pctasks/dataset/chunks/task.py
+++ b/pctasks/dataset/pctasks/dataset/chunks/task.py
@@ -56,6 +56,7 @@ class CreateChunksTask(Task[CreateChunksInput, ChunksOutput]):
             matches=input.options.matches,
             file_limit=input.options.limit,
             max_depth=input.options.max_depth,
+            min_depth=input.options.min_depth,
         ):
             if input.options.list_folders:
                 gen = folders

--- a/pctasks/dataset/pctasks/dataset/models.py
+++ b/pctasks/dataset/pctasks/dataset/models.py
@@ -66,6 +66,9 @@ class ChunkOptions(PCBaseModel):
     limit: Optional[int] = None
     """Limit the number of URIs to process. """
 
+    min_depth: Optional[int] = None
+    """Minimum number of directories to descend into."""
+
     max_depth: Optional[int] = None
     """Maximum number of directories to descend into."""
 


### PR DESCRIPTION
This updates the `ms-buildings` collection for some recent data and STAC metadata updates / changes.

The newest set of data (2023-04-25) have been rewritten in delta format, which offers scalable metadata handling (specifically partitioning and statistics, which can speed up access times to avoid touching large numbers of files in Blob Storage).

I've added a link to the delta table as a new collection-level asset (will update the example notebook shortly)

This also updates to the latest version of `stactools-msbuildings`, which

1. targets quadkey level items, rather than region level. This will make spatial searchers more useful
2. adds an `msbuildings:processing-date` property

Finally, I've added a pctasks task for creating the STAC items. Older items were created out of band and imported using the premade STAC item collection.

Note that this required slightly updating `pctasks`' chunk options to add a `min_depth` argument to pass through to `walk`.