### PR TITLE
Add option to auto-confirm submits in dataset cli

### DIFF
--- a/pctasks/client/pctasks/client/workflow/commands.py
+++ b/pctasks/client/pctasks/client/workflow/commands.py
@@ -181,6 +181,7 @@ def submit_workflow(
     workflow_id: str,
     args: Optional[Dict[str, Any]],
     client: Optional[PCTasksClient] = None,
+    auto_confirm: bool = False,
 ) -> int:
     """Submit a workflow to the PCTasks task queue."""
     if not client:
@@ -188,7 +189,9 @@ def submit_workflow(
 
     try:
         submit_result = client.submit_workflow(
-            workflow_id, WorkflowSubmitRequest(args=args) if args else None
+            workflow_id,
+            WorkflowSubmitRequest(args=args) if args else None,
+            auto_confirm=auto_confirm,
         )
     except ConfirmationError:
         cli_print("[red]Submit cancelled by user[/red]")
@@ -240,6 +243,7 @@ def cli_handle_workflow(
     upsert: bool = False,
     upsert_and_submit: bool = False,
     client: Optional[PCTasksClient] = None,
+    auto_confirm: bool = False,
 ) -> int:
     """Handle a workflow definition created through the CLI.
 
@@ -267,10 +271,12 @@ def cli_handle_workflow(
 
     if upsert or upsert_and_submit:
         cli_print(f"[green]  Saving {workflow_id}...[/green]")
-        client.upsert_workflow(workflow_def)
+        client.upsert_workflow(workflow_def, auto_confirm=auto_confirm)
         if upsert_and_submit:
             cli_print(f"[green]  Submitting {workflow_id}...[/green]")
-            return submit_workflow(ctx, workflow_id, args, client=client)
+            return submit_workflow(
+                ctx, workflow_id, args, client=client, auto_confirm=auto_confirm
+            )
         else:
             cli_output(workflow_id)
             return 0

--- a/pctasks/dataset/pctasks/dataset/_cli.py
+++ b/pctasks/dataset/pctasks/dataset/_cli.py
@@ -41,6 +41,7 @@ def create_chunks_cmd(
     since: Optional[str] = None,
     limit: Optional[int] = None,
     submit: bool = False,
+    auto_confirm: bool = False,
     upsert: bool = False,
     target: Optional[str] = None,
     workflow_id: Optional[str] = None,
@@ -84,6 +85,7 @@ def create_chunks_cmd(
         upsert=upsert,
         upsert_and_submit=submit,
         args={a[0]: a[1] for a in arg},
+        auto_confirm=auto_confirm,
     )
 
 
@@ -99,6 +101,7 @@ def process_items_cmd(
     since: Optional[str] = None,
     limit: Optional[int] = None,
     submit: bool = False,
+    auto_confirm: bool = False,
     upsert: bool = False,
     workflow_id: Optional[str] = None,
     is_update_workflow: bool = False,
@@ -151,6 +154,7 @@ def process_items_cmd(
         upsert=upsert,
         upsert_and_submit=submit,
         args={a[0]: a[1] for a in arg},
+        auto_confirm=auto_confirm,
     )
 
 
@@ -161,6 +165,7 @@ def ingest_collection_cmd(
     arg: List[Tuple[str, str]] = [],
     target: Optional[str] = None,
     submit: bool = False,
+    auto_confirm: bool = False,
     upsert: bool = False,
     workflow_id: Optional[str] = None,
 ) -> None:
@@ -209,6 +214,7 @@ def ingest_collection_cmd(
         upsert=upsert,
         upsert_and_submit=submit,
         args={a[0]: a[1] for a in arg},
+        auto_confirm=auto_confirm,
     )
 
 

--- a/pctasks/dataset/pctasks/dataset/cli.py
+++ b/pctasks/dataset/pctasks/dataset/cli.py
@@ -6,6 +6,7 @@ import click
 from pctasks.client.workflow.options import opt_args
 from pctasks.dataset.utils import (
     opt_collection,
+    opt_confirm,
     opt_ds_config,
     opt_submit,
     opt_upsert,
@@ -39,6 +40,7 @@ def dataset_cmd(ctx: click.Context) -> None:
     help="The target environment to process the items in.",
 )
 @opt_submit
+@opt_confirm
 @opt_upsert
 @opt_workflow_id
 @click.pass_context
@@ -52,6 +54,7 @@ def create_chunks_cmd(
     limit: Optional[int] = None,
     target: Optional[str] = None,
     submit: bool = False,
+    confirm: bool = False,
     upsert: bool = False,
     workflow_id: Optional[str] = None,
 ) -> None:
@@ -78,6 +81,7 @@ def create_chunks_cmd(
         upsert=upsert,
         target=target,
         workflow_id=workflow_id,
+        auto_confirm=confirm,
     )
 
 
@@ -110,6 +114,7 @@ def create_chunks_cmd(
     help="Make an 'update' workflow by adding 'since' to the runtime arguments.",
 )
 @opt_submit
+@opt_confirm
 @opt_upsert
 @opt_workflow_id
 @click.pass_context
@@ -125,6 +130,7 @@ def process_items_cmd(
     since: Optional[str] = None,
     limit: Optional[int] = None,
     submit: bool = False,
+    confirm: bool = False,
     upsert: bool = False,
     workflow_id: Optional[str] = None,
     is_update_workflow: bool = False,
@@ -159,6 +165,7 @@ def process_items_cmd(
         upsert=upsert,
         workflow_id=workflow_id,
         is_update_workflow=is_update_workflow,
+        auto_confirm=confirm,
     )
 
 
@@ -172,6 +179,7 @@ def process_items_cmd(
     help="The target environment to process the items in.",
 )
 @opt_submit
+@opt_confirm
 @opt_upsert
 @opt_workflow_id
 @click.pass_context
@@ -182,6 +190,7 @@ def ingest_collection_cmd(
     arg: List[Tuple[str, str]] = [],
     target: Optional[str] = None,
     submit: bool = False,
+    confirm: bool = False,
     upsert: bool = False,
     workflow_id: Optional[str] = None,
 ) -> None:
@@ -209,6 +218,7 @@ def ingest_collection_cmd(
         submit=submit,
         upsert=upsert,
         workflow_id=workflow_id,
+        auto_confirm=confirm,
     )
 
 

--- a/pctasks/dataset/pctasks/dataset/utils.py
+++ b/pctasks/dataset/pctasks/dataset/utils.py
@@ -45,6 +45,14 @@ def opt_submit(fn: Callable[..., Any]) -> Callable[..., Any]:
     return fn
 
 
+def opt_confirm(fn: Callable[..., Any]) -> Callable[..., Any]:
+    _opt = click.option(
+        "-y", "--confirm", is_flag=True, help="Auto-approve submission confirmation."
+    )
+    _opt(fn)
+    return fn
+
+
 def opt_workflow_id(fn: Callable[..., Any]) -> Callable[..., Any]:
     _opt = click.option(
         "--workflow-id",


### PR DESCRIPTION
This adds a `-y` option to the dataset commands that allows skipping of user input for submitting workflows. This is useful for e.g. iterating over collections to submit ingest commands:

```shell
> pctasks dataset list-collections -d datasets/sentinel-3/dataset.yaml | xargs -I {} \
    pctasks dataset ingest-collection -d datasets/sentinel-3/dataset.yaml -c {} -s -y
```