### PR TITLE
Update `helm/kind-action`  version

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,7 @@ jobs:
       # Integration Tests
 
       - name: Install Kind
-        uses: helm/kind-action@1.5.0
+        uses: helm/kind-action@v1.4.0
         with:
           install_only: true
         if: ${{ github.base_ref  == 'main' }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,6 +37,9 @@ jobs:
         uses: helm/kind-action@v1.4.0
         with:
           install_only: true
+          version: "v0.17.0"
+          kubectl_version: "v.1.25.5"
+
         if: ${{ github.base_ref  == 'main' }}
 
       - name: Install Helm

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -37,9 +37,6 @@ jobs:
         uses: helm/kind-action@v1.4.0
         with:
           install_only: true
-          version: "v0.17.0"
-          kubectl_version: "v.1.25.5"
-
         if: ${{ github.base_ref  == 'main' }}
 
       - name: Install Helm

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -34,7 +34,7 @@ jobs:
       # Integration Tests
 
       - name: Install Kind
-        uses: helm/kind-action@deab45fc8df9de5090a604e8ec11778eea7170bd
+        uses: helm/kind-action@1.5.0
         with:
           install_only: true
         if: ${{ github.base_ref  == 'main' }}

--- a/cluster/kind-config.yaml
+++ b/cluster/kind-config.yaml
@@ -2,6 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
+  image: kindest/node:v1.26.3@sha256:61b92f38dff6ccc29969e7aa154d34e38b89443af1a2c14e6cfbd2df6419c66f
   kubeadmConfigPatches:
   - |
     kind: InitConfiguration


### PR DESCRIPTION
In https://github.com/microsoft/planetary-computer-tasks/pull/201, we're adding KEDA for scaling the streaming pipelines. KEDA currently requires Kubernetes 1.24.

This updates the `kind` action to a version compatible with Kubernetes 1.24 and newer, and bumps the Kubernetes version we're using.