### PR TITLE
Bump kind version in cicd action

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -43,7 +43,7 @@ jobs:
       # Integration Tests
 
       - name: Install Kind
-        uses: helm/kind-action@deab45fc8df9de5090a604e8ec11778eea7170bd
+        uses: helm/kind-action@v1.4.0
         with:
           install_only: true
 


### PR DESCRIPTION
In https://github.com/microsoft/planetary-computer-tasks/pull/202 we updated the version of Kind used in the `pr` GitHub Acvtion, to support newer Kubernetes versions.

This makes the same change in the `cicd` action.