### PR TITLE
Correct gdpcir is now made up of 2 collections

### DIFF
--- a/datasets/cil-gdpcir/collection/cil-gdpcir-cc-by/description.md
+++ b/datasets/cil-gdpcir/collection/cil-gdpcir-cc-by/description.md
@@ -4,7 +4,7 @@ The [Global Downscaled Projections for Climate Impacts Research](https://github.
 
 ## Accessing the data
 
-GDPCIR data can be accessed on the Microsoft Planetary Computer. The dataset is made of of three collections, distinguished by data license:
+GDPCIR data can be accessed on the Microsoft Planetary Computer. The dataset is made of of two collections, distinguished by data license:
 * [Public domain (CC0-1.0) collection](https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc0)
 * [Attribution (CC BY 4.0) collection](https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc-by)
 

--- a/datasets/cil-gdpcir/collection/cil-gdpcir-cc0/description.md
+++ b/datasets/cil-gdpcir/collection/cil-gdpcir-cc0/description.md
@@ -4,7 +4,7 @@ The [Global Downscaled Projections for Climate Impacts Research](https://github.
 
 ## Accessing the data
 
-GDPCIR data can be accessed on the Microsoft Planetary Computer. The dataset is made of of three collections, distinguished by data license:
+GDPCIR data can be accessed on the Microsoft Planetary Computer. The dataset is made of of two collections, distinguished by data license:
 * [Public domain (CC0-1.0) collection](https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc0)
 * [Attribution (CC BY 4.0) collection](https://planetarycomputer.microsoft.com/dataset/cil-gdpcir-cc-by)
 


### PR DESCRIPTION
## Description

Tiny edit - GDPCIR group no longer has three collections, as the CC-BY-SA license has been changed to a CC-BY licenses and these groups were merged.

See also:
* https://github.com/microsoft/PlanetaryComputerDataCatalog/pull/438
* https://github.com/microsoft/PlanetaryComputerDataCatalog/pull/442

Related PRs on ClimateImpactLab repo:
* https://github.com/ClimateImpactLab/downscaleCMIP6/pull/637
* https://github.com/ClimateImpactLab/downscaleCMIP6/issues/660

@TomAugspurger 

## Type of change

- [x] Documentation change only

## Checklist:

- [x] I have performed a self-review