### PR TITLE
Set `username` for CI/CD deployment

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -112,3 +112,4 @@ jobs:
           ENVIRONMENT: staging
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          TF_VAR_username: staging

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -112,4 +112,3 @@ jobs:
           ENVIRONMENT: staging
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-          TF_VAR_username: staging

--- a/deployment/terraform/staging/variables.tf
+++ b/deployment/terraform/staging/variables.tf
@@ -1,8 +1,3 @@
-variable "username" {
-  description = "Username for tagging infrastructure dedicated to you"
-  type        = string
-}
-
 variable "region" {
   description = "Azure region for infrastructure"
   type        = string


### PR DESCRIPTION
Currently, the `deploy` stage of CD is failing after https://github.com/microsoft/planetary-computer-tasks/pull/186 thanks to the `username` terraform variable not being set (e.g. https://github.com/microsoft/planetary-computer-tasks/actions/runs/5329010562/jobs/9654894797).

This PR sets it to `staging` in the GitHub Actions file.