### PR TITLE
Added terraform variable to set API Management sku_name

### DIFF
--- a/deployment/terraform/dev/main.tf
+++ b/deployment/terraform/dev/main.tf
@@ -48,4 +48,5 @@ module "resources" {
   cluster_cert_server = "https://acme-v02.api.letsencrypt.org/directory"
   aks_node_count = 1
   pctasks_server_replica_count = 1
+  apim_sku_name = var.apim_sku_name
 }

--- a/deployment/terraform/dev/variables.tf
+++ b/deployment/terraform/dev/variables.tf
@@ -146,3 +146,10 @@ variable "pctasks_server_sp_client_secret" {
 variable "pctasks_server_sp_object_id" {
   type    = string
 }
+
+## APIM
+
+variable "apim_sku_name" {
+  type = string
+  default = "Consumption_0"
+}

--- a/deployment/terraform/dev/variables.tf
+++ b/deployment/terraform/dev/variables.tf
@@ -151,5 +151,5 @@ variable "pctasks_server_sp_object_id" {
 
 variable "apim_sku_name" {
   type = string
-  default = "Consumption_0"
+  default = "Developer_1"
 }

--- a/deployment/terraform/resources/apim.tf
+++ b/deployment/terraform/resources/apim.tf
@@ -5,7 +5,7 @@ resource "azurerm_api_management" "pctasks" {
   publisher_name      = "Microsoft"
   publisher_email     = "planetarycomputer@microsoft.com"
 
-  sku_name = "Standard_1"
+  sku_name = var.apim_sku_name
 
   identity {
     type = "SystemAssigned"

--- a/deployment/terraform/resources/variables.tf
+++ b/deployment/terraform/resources/variables.tf
@@ -6,6 +6,13 @@ variable "region" {
   type = string
 }
 
+# APIM
+
+variable "apim_sku_name" {
+  type    = string
+  default = "Standard_1"
+}
+
 ## AKS
 
 variable "cluster_cert_issuer" {

--- a/deployment/terraform/staging/main.tf
+++ b/deployment/terraform/staging/main.tf
@@ -49,4 +49,5 @@ module "resources" {
   cluster_cert_server = "https://acme-v02.api.letsencrypt.org/directory"
   aks_node_count = 2
   pctasks_server_replica_count = 1
+  apim_sku_name = var.apim_sku_name
 }

--- a/deployment/terraform/staging/variables.tf
+++ b/deployment/terraform/staging/variables.tf
@@ -136,3 +136,10 @@ variable "pctasks_server_sp_client_secret" {
 variable "pctasks_server_sp_object_id" {
   type    = string
 }
+
+# APIM
+
+variable "apim_sku_name" {
+  type    = string
+  default = "Consumption_0"
+}

--- a/deployment/terraform/staging/variables.tf
+++ b/deployment/terraform/staging/variables.tf
@@ -141,5 +141,5 @@ variable "pctasks_server_sp_object_id" {
 
 variable "apim_sku_name" {
   type    = string
-  default = "Consumption_0"
+  default = "Developer_1"
 }


### PR DESCRIPTION
This adds a new variable to the deployment to set the [API management SKU name](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/api_management#sku_name). The default is set to `Standard_1` (no change). We set it to `Consumption_0` for our test / dev envs.

I'm testing a deploy to `dev` now.