### PR TITLE
[sentinel-1-grd]: Write out STAC items

### DIFF
--- a/datasets/sentinel-1-grd/s1grd.py
+++ b/datasets/sentinel-1-grd/s1grd.py
@@ -94,11 +94,8 @@ def get_item_storage(asset_uri: str, storage_factory: StorageFactory) -> Storage
     else:
         prefix = stac_item_container_name
         path = os.path.dirname(asset_uri)
-    stac_item_storage = storage_factory.get_storage(
-        f"{prefix}/{path}.json"
-    )
+    stac_item_storage = storage_factory.get_storage(f"{prefix}/{path}.json")
     return stac_item_storage
-
 
 
 class S1GRDCollection(Collection):

--- a/datasets/sentinel-1-grd/test_s1grd.py
+++ b/datasets/sentinel-1-grd/test_s1grd.py
@@ -1,0 +1,12 @@
+import s1grd
+from pctasks.core.storage import StorageFactory
+
+
+def test_get_item_storage():
+    asset_uri = "blob://sentinel1euwest/s1-grd/GRD/2023/6/20/EW/DH/S1A_EW_GRDM_1SDH_20230620T020009_20230620T020113_049063_05E665_5673/manifest.safe"  # noqa: E501
+    storage_factory = StorageFactory()
+    result = s1grd.get_item_storage(asset_uri, storage_factory=storage_factory)
+    expected = storage_factory.get_storage(
+        "blob://sentinel1euwest/s1-grd-stac/GRD/2023/6/20/EW/DH/S1A_EW_GRDM_1SDH_20230620T020009_20230620T020113_049063_05E665_5673.json"  # noqa: E501
+    )
+    assert result.root_uri == expected.root_uri


### PR DESCRIPTION
In addition to creating the STAC item, we also write out the JSON to another storage container for another processing pipeline.