### PR TITLE
Tom/fix/goes glm timeout error

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,3 +5,6 @@ __pycache__
 .pytest_cache
 .terraform
 node_modules
+**/.mypy_cache
+**/.pytest_cache
+**/.terraform

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,10 +1,8 @@
-.envrc
-.direnv
-__pycache__
-.mypy_cache
-.pytest_cache
-.terraform
-node_modules
+**/.envrc
+**/.direnv
+**/__pycache__
 **/.mypy_cache
 **/.pytest_cache
+**/.terraform
+**/node_modules
 **/.terraform

--- a/datasets/goes/goes-cmi/dataset.yaml
+++ b/datasets/goes/goes-cmi/dataset.yaml
@@ -1,5 +1,5 @@
 id: goes_cmi
-image: ${{ args.registry }}/pctasks-goes-cmi:20230612.3
+image: ${{ args.registry }}/pctasks-goes-cmi:2023.7.6.0
 
 args:
 - registry

--- a/datasets/goes/goes-glm/dataset.yaml
+++ b/datasets/goes/goes-glm/dataset.yaml
@@ -1,5 +1,5 @@
 id: goes_glm
-image: ${{ args.registry }}/pctasks-goes-glm:2023.4.24.0
+image: ${{ args.registry }}/pctasks-goes-glm:2023.7.5.0
 
 args:
 - registry

--- a/datasets/goes/goes-glm/dataset.yaml
+++ b/datasets/goes/goes-glm/dataset.yaml
@@ -1,5 +1,5 @@
 id: goes_glm
-image: ${{ args.registry }}/pctasks-goes-glm:2023.7.5.0
+image: ${{ args.registry }}/pctasks-goes-glm:2023.7.6.0
 
 args:
 - registry

--- a/datasets/goes/goes-glm/workflows/goes-glm-update.yaml
+++ b/datasets/goes/goes-glm/workflows/goes-glm-update.yaml
@@ -14,7 +14,7 @@ jobs:
     id: create-splits
     tasks:
     - id: create-splits
-      image: ${{ args.registry }}/pctasks-goes-glm:2023.5.18.0
+      image: ${{ args.registry }}/pctasks-goes-glm:2023.7.5.0
       code:
         src: datasets/goes/goes-glm/goes_glm.py
       task: goes_glm:GoesGlmCollection.create_splits_task
@@ -53,7 +53,7 @@ jobs:
     id: create-chunks
     tasks:
     - id: create-chunks
-      image: ${{ args.registry }}/pctasks-goes-glm:2023.5.18.0
+      image: ${{ args.registry }}/pctasks-goes-glm:2023.7.5.0
       code:
         src: datasets/goes/goes-glm/goes_glm.py
       task: pctasks.dataset.chunks.task:create_chunks_task
@@ -74,7 +74,7 @@ jobs:
     id: process-chunk
     tasks:
     - id: create-items
-      image: ${{ args.registry }}/pctasks-goes-glm:2023.5.18.0
+      image: ${{ args.registry }}/pctasks-goes-glm:2023.7.5.0
       code:
         src: datasets/goes/goes-glm/goes_glm.py
       task: goes_glm:GoesGlmCollection.create_items_task

--- a/datasets/modis/dataset.yaml
+++ b/datasets/modis/dataset.yaml
@@ -1,5 +1,5 @@
 id: modis
-image: ${{ args.registry }}/pctasks-modis:20230613.1
+image: ${{ args.registry }}/pctasks-modis:2023.7.6.0
 
 args:
 - registry

--- a/pctasks/core/pctasks/core/utils/backoff.py
+++ b/pctasks/core/pctasks/core/utils/backoff.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass, field
 from typing import Any, Callable, Coroutine, List, Optional, TypeVar
 
 import azure.core.exceptions
+import requests
 
 T = TypeVar("T")
 
@@ -78,7 +79,14 @@ def is_common_throttle_exception(e: Exception) -> bool:
         # urllib3.exceptions.ProtocolError uses 104 for connection reset by peer
         return True
 
-    if isinstance(e, azure.core.exceptions.IncompleteReadError):
+    if isinstance(
+        e,
+        (
+            azure.core.exceptions.IncompleteReadError,
+            requests.exceptions.ConnectionError,
+            TimeoutError,
+        ),
+    ):
         return True
 
     return False
@@ -137,7 +145,6 @@ def with_backoff(
 
     for next_wait in strategy.get_waits():
         try:
-
             # Try to do the thing and return
             return fn()
 
@@ -172,7 +179,6 @@ async def with_backoff_async(
 
     for next_wait in strategy.get_waits():
         try:
-
             # Try to do the thing and return
             return await fn()
 

--- a/pctasks/core/tests/utils/test_backoff.py
+++ b/pctasks/core/tests/utils/test_backoff.py
@@ -1,0 +1,33 @@
+import pytest
+import requests.exceptions
+import azure.core.exceptions
+
+from pctasks.core.utils.backoff import with_backoff
+
+
+@pytest.mark.parametrize('kind', [
+    TimeoutError,
+    requests.exceptions.ConnectionError,
+    azure.core.exceptions.IncompleteReadError,
+])
+def test_retry_timeout_errors(kind):
+
+    i = 0
+
+    def make_callable(kind):
+
+        def fn():
+            nonlocal i
+            i += 1
+
+            if i > 2:
+                return True
+            else:
+                raise kind()
+        return fn
+        
+
+    result = with_backoff(make_callable(kind))
+    assert i == 3
+    assert result is True
+

--- a/pctasks/core/tests/utils/test_backoff.py
+++ b/pctasks/core/tests/utils/test_backoff.py
@@ -1,21 +1,23 @@
+import azure.core.exceptions
 import pytest
 import requests.exceptions
-import azure.core.exceptions
 
 from pctasks.core.utils.backoff import with_backoff
 
 
-@pytest.mark.parametrize('kind', [
-    TimeoutError,
-    requests.exceptions.ConnectionError,
-    azure.core.exceptions.IncompleteReadError,
-])
+@pytest.mark.parametrize(
+    "kind",
+    [
+        TimeoutError,
+        requests.exceptions.ConnectionError,
+        azure.core.exceptions.IncompleteReadError,
+    ],
+)
 def test_retry_timeout_errors(kind):
 
     i = 0
 
     def make_callable(kind):
-
         def fn():
             nonlocal i
             i += 1
@@ -24,10 +26,9 @@ def test_retry_timeout_errors(kind):
                 return True
             else:
                 raise kind()
+
         return fn
-        
 
     result = with_backoff(make_callable(kind))
     assert i == 3
     assert result is True
-


### PR DESCRIPTION
Adds `TimeoutError` and `ConnectionError` to the list of retried exceptions in `with_backoff`.

It's not clear to me whether or not this was previously being retried, but the goes-glm pipeline has failed with

```
requests.exceptions.ConnectionError:
HTTPSConnectionPool(host='goeseuwest.blob.core.windows.net', port=443):
Read timed out.
```

I'd have thought that `azure-storage-blob` is retrying that, but I'm not sure.