### PR TITLE
[dataset]: Fixed update workflow with multi-input

### DIFF
--- a/pctasks/dataset/pctasks/dataset/workflow.py
+++ b/pctasks/dataset/pctasks/dataset/workflow.py
@@ -251,9 +251,9 @@ def create_process_items_workflow(
             workflow_definition = workflow_definition.copy(update={"args": ["since"]})
         else:
             workflow_definition.args.append("since")
-        workflow_definition.jobs["create-splits"].tasks[0].args["inputs"][0][
-            "chunk_options"
-        ]["since"] = "${{ args.since }}"
+        
+        for input_ in workflow_definition.jobs["create-splits"].tasks[0].args["inputs"]:
+            input_["chunk_options"]["since"] = "${{ args.since }}"
 
     return workflow_definition
 

--- a/pctasks/dataset/pctasks/dataset/workflow.py
+++ b/pctasks/dataset/pctasks/dataset/workflow.py
@@ -251,7 +251,7 @@ def create_process_items_workflow(
             workflow_definition = workflow_definition.copy(update={"args": ["since"]})
         else:
             workflow_definition.args.append("since")
-        
+
         for input_ in workflow_definition.jobs["create-splits"].tasks[0].args["inputs"]:
             input_["chunk_options"]["since"] = "${{ args.since }}"
 

--- a/pctasks/dataset/tests/test_dataset.py
+++ b/pctasks/dataset/tests/test_dataset.py
@@ -92,7 +92,7 @@ def test_process_items() -> None:
 @pytest.mark.parametrize("has_args", [True, False])
 @pytest.mark.parametrize("extra_uri", [True, False])
 def test_process_items_is_update_workflow(tmp_path, has_args, extra_uri) -> None:
-    
+
     workflow_path = tmp_path.joinpath("workflow.yaml")
     workflow_path.write_text(Path(DATASET_PATH).read_text())
 

--- a/pctasks/dataset/tests/test_dataset.py
+++ b/pctasks/dataset/tests/test_dataset.py
@@ -90,8 +90,18 @@ def test_process_items() -> None:
 
 
 @pytest.mark.parametrize("has_args", [True, False])
-def test_process_items_is_update_workflow(has_args) -> None:
-    ds_config = template_dataset_file(DATASET_PATH)
+@pytest.mark.parametrize("extra_uri", [True, False])
+def test_process_items_is_update_workflow(tmp_path, has_args, extra_uri) -> None:
+    
+    workflow_path = tmp_path.joinpath("workflow.yaml")
+    workflow_path.write_text(Path(DATASET_PATH).read_text())
+
+    ds_config = template_dataset_file(workflow_path)
+
+    if extra_uri:
+        asset_storage = ds_config.collections[0].asset_storage
+        asset_storage.append(asset_storage[0].copy())
+
     if not has_args:
         ds_config = ds_config.copy(update={"args": None})
         assert ds_config.args is None
@@ -113,6 +123,14 @@ def test_process_items_is_update_workflow(has_args) -> None:
         .args["inputs"][0]["chunk_options"]["since"]
         == "${{ args.since }}"
     )
+
+    if extra_uri:
+        assert (
+            workflow.jobs["create-splits"]
+            .tasks[0]
+            .args["inputs"][1]["chunk_options"]["since"]
+            == "${{ args.since }}"
+        )
 
 
 def test_task_config_tags() -> None:


### PR DESCRIPTION
Previously, `--is-update-workflow` would only add the `--since` argument to the first `input` in the `create-splits` task. Workflows like modis, with multiple inputs, would try recreating STAC items for every item for the later inputs under `asset_storage`.