### PR TITLE
Error loudly in s1-grd

### DIFF
--- a/datasets/sentinel-1-grd/s1grd.py
+++ b/datasets/sentinel-1-grd/s1grd.py
@@ -1,5 +1,7 @@
 import logging
 import os
+import json
+import pathlib
 from tempfile import TemporaryDirectory
 from typing import List, Tuple, Union
 
@@ -137,15 +139,9 @@ class S1GRDCollection(Collection):
                     is_throttle=backoff_throttle_check,
                 )
 
-            try:
-                item: pystac.Item = create_item(
-                    temp_archive_dir, archive_format=Format.COG
-                )
-            except FileNotFoundError:
-                logger.exception(
-                    f"Missing file when attempting to create item for {asset_uri}"
-                )
-                return []
+            item: pystac.Item = create_item(
+                temp_archive_dir, archive_format=Format.COG
+            )
 
             for asset in item.assets.values():
                 path = os.path.basename(asset.href)

--- a/datasets/sentinel-1-grd/s1grd.py
+++ b/datasets/sentinel-1-grd/s1grd.py
@@ -1,7 +1,5 @@
 import logging
 import os
-import json
-import pathlib
 from tempfile import TemporaryDirectory
 from typing import List, Tuple, Union
 


### PR DESCRIPTION
This removes a try/except in s1-grd that was silencing real errors.
```
$ pctasks runs get task-log 5748c0ed-092d-472d-bab5-1a982699cf37 process-chunk create-items
[ERROR] 2023-07-07 13:41:37,629 - Missing file when attempting to create item for blob://sentinel1euwest/s1-grd/GRD/2023/7/5/IW/DV/S1A_IW_GRDH_1SDV_20230705T170135_20230705T170200_049291_05ED53_649F/manifest.safe
Traceback (most recent call last):
  File "/mnt/batch/tasks/workitems/sentinel-1-grd-process-chunk-574-2d-bab5-1a982699cf37-tsk_gen_gr/job-1/create-items-0/wd/_code/s1grd.py", line 141, in create_item
    item: pystac.Item = create_item(
  File "/opt/conda/lib/python3.8/site-packages/stactools/sentinel1/grd/stac.py", line 101, in create_item
    metalinks = MetadataLinks(
  File "/opt/conda/lib/python3.8/site-packages/stactools/sentinel1/grd/metadata_links.py", line 92, in __init__
    stactools.core.io.read_text(
  File "/opt/conda/lib/python3.8/site-packages/stactools/core/io/__init__.py", line 43, in read_text
    return StacIO.default().read_text(href, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/stactools/core/io/__init__.py", line 59, in read_text
    return self.read_text_from_href(href, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/stactools/core/io/__init__.py", line 72, in read_text_from_href
    with fsspec.open(href, "r", **kwargs) as f:
  File "/opt/conda/lib/python3.8/site-packages/fsspec/core.py", line 102, in __enter__
    f = self.fs.open(self.path, mode=mode)
  File "/opt/conda/lib/python3.8/site-packages/fsspec/spec.py", line 1241, in open
    f = self._open(
  File "/opt/conda/lib/python3.8/site-packages/fsspec/implementations/local.py", line 184, in _open
    return LocalFileOpener(path, mode, fs=self, **kwargs)
  File "/opt/conda/lib/python3.8/site-packages/fsspec/implementations/local.py", line 315, in __init__
    self._open()
  File "/opt/conda/lib/python3.8/site-packages/fsspec/implementations/local.py", line 320, in _open
    self.f = open(self.path, mode=self.mode)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmp8zma3mh0/S1A_IW_GRDH_1SDV_20230705T170135_20230705T170200_049291_05ED53_649F/productInfo.json'
```