### PR TITLE
[CI]: Update container images

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,13 +8,15 @@ ENV LANG=C.UTF-8
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
-RUN apt-get update && apt-get install -y software-properties-common
+RUN apt-get update && apt-get install -y software-properties-common && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN add-apt-repository ppa:ubuntugis/ppa && \
      apt-get update && \
      apt-get install -y build-essential python3-dev python3-pip \
      jq unzip ca-certificates wget curl && \
-     apt-get autoremove && apt-get autoclean && apt-get clean
+     apt-get autoremove && apt-get autoclean && apt-get clean && \
+     rm -rf /var/lib/apt/lists/*
 
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
 

--- a/Dockerfile.task_base
+++ b/Dockerfile.task_base
@@ -5,6 +5,7 @@ ENV TZ=UTC
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
+ENV PIP_NO_CACHE_DIR=1
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/docker-compose.aux.yml
+++ b/docker-compose.aux.yml
@@ -38,6 +38,22 @@ services:
     ports:
       - "8514:8080"
 
+  frontend:
+    container_name: pctasks-frontend-app
+    image: node:16.16-slim
+    working_dir: /usr/src/app
+    env_file:
+      - "pctasks_frontend/.env"
+    ports:
+      - "8515:8515"
+    environment:
+      - CHOKIDAR_USEPOLLING=true
+      - CHOKIDAR_INTERVAL=100
+      - REACT_APP_DEV_AUTH_TOKEN=${REACT_APP_DEV_AUTH_TOKEN:-hunter2}
+    volumes:
+      - ./pctasks_frontend:/usr/src/app
+    command: "npm start"
+
 networks:
   default:
     # Network created during scripts/setup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -154,22 +154,6 @@ services:
         "--proxy-headers"
       ]
 
-  frontend:
-    container_name: pctasks-frontend-app
-    image: node:16.16-slim
-    working_dir: /usr/src/app
-    env_file:
-      - "pctasks_frontend/.env"
-    ports:
-      - "8515:8515"
-    environment:
-      - CHOKIDAR_USEPOLLING=true
-      - CHOKIDAR_INTERVAL=100
-      - REACT_APP_DEV_AUTH_TOKEN=${REACT_APP_DEV_AUTH_TOKEN:-hunter2}
-    volumes:
-      - ./pctasks_frontend:/usr/src/app
-    command: "npm start"
-
   # Used to let kind cluster pull local docker images
   # See https://kind.sigs.k8s.io/docs/user/local-registry/
   local-docker-registry:

--- a/docs/development/setup.md
+++ b/docs/development/setup.md
@@ -54,7 +54,7 @@ to inspect ingest results, and the frontend.
 | STAC API          | <http://localhost:8513>      |
 | STAC Browser      | <http://localhost:8514>      |
 
-You can avoid building or bringing up the STAC API and STAC Browser
+You can avoid building or bringing up the frontend, STAC API, and STAC Browser
 servers by using the flag `--no-aux-servers` in `scripts/setup`,
 `scripts/update`, and `scripts/server`. This can save on build time
 and memory footprint if you are not using those services.

--- a/pctasks/.dockerignore
+++ b/pctasks/.dockerignore
@@ -1,0 +1,8 @@
+**/.envrc
+**/.direnv
+**/__pycache__
+**/.mypy_cache
+**/.pytest_cache
+**/.terraform
+**/node_modules
+**/.terraform

--- a/pctasks/run/Dockerfile
+++ b/pctasks/run/Dockerfile
@@ -4,6 +4,7 @@ RUN apt-get update && \
     apt-get install -y build-essential git
 
 ENV CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
+ENV PIP_NO_CACHE_DIR=1
 
 WORKDIR /opt/src
 

--- a/pctasks/server/Dockerfile
+++ b/pctasks/server/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 ENV CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
+ENV PIP_NO_CACHE_DIR=1
 
 WORKDIR /opt/src
 

--- a/pctasks/server/Dockerfile
+++ b/pctasks/server/Dockerfile
@@ -3,7 +3,8 @@ FROM python:3.9-slim
 ARG DEVELOPMENT=FALSE
 
 RUN apt-get update && \
-    apt-get install -y build-essential git
+    apt-get install -y build-essential git && \
+    rm -rf /var/lib/apt/lists/*
 
 ENV CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
 

--- a/scripts/update
+++ b/scripts/update
@@ -77,6 +77,7 @@ while [[ $# -gt 0 ]]; do case $1 in
         ;;
     --no-aux-servers)
         BUILD_AUX_SERVERS=""
+        BUILD_FRONTEND=""
         shift
         ;;
     --task)


### PR DESCRIPTION
* moved pctasks-frontend to an aux server
* shrink container images a bit

Trying to fix the CI failures at https://github.com/microsoft/planetary-computer-tasks/actions/runs/5579847626/jobs/10195946932#step:11:419, where we seem to be running out of disk space.

```
--- ErrImagePull: rpc error: code = Unknown desc = failed to pull and unpack image "localhost:5001/pctasks-ingest:latest": failed to extract layer sha256:d32bc1b36f4802dd6c638c4501c6eb836f140b71383c0d5e87db50115060811a: write /var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/285/fs/opt/az/lib/python3.10/site-packages/azure/synapse/artifacts/models/__pycache__/_models_py3.cpython-310.pyc: no space left on device: unknown

[419](https://github.com/microsoft/planetary-computer-tasks/actions/runs/5579847626/jobs/10195946932#step:11:420)
```