### PR TITLE
Optimize task images

### DIFF
--- a/Dockerfile.task_base
+++ b/Dockerfile.task_base
@@ -1,4 +1,4 @@
-FROM ubuntu:20.04
+FROM python:3.9-slim
 
 # Setup timezone info
 ENV TZ=UTC
@@ -8,31 +8,6 @@ ENV LANG=C.UTF-8
 ENV PIP_NO_CACHE_DIR=1
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
-RUN apt-get update && apt-get install -y software-properties-common
-
-RUN add-apt-repository ppa:ubuntugis/ppa && \
-     apt-get update && \
-     apt-get install -y build-essential python3-dev python3-pip \
-     jq unzip ca-certificates wget curl git && \
-     apt-get autoremove && apt-get autoclean && apt-get clean
-
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-
-# See https://github.com/mapbox/rasterio/issues/1289
-ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
-
-# Install Python 3.8
-RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/Mambaforge-$(uname)-$(uname -m).sh" \
-   && bash "Mambaforge-$(uname)-$(uname -m).sh" -b -p /opt/conda \
-   && rm -rf "Mambaforge-$(uname)-$(uname -m).sh"
-
-ENV PATH /opt/conda/bin:$PATH
-ENV LD_LIBRARY_PATH /opt/conda/lib/:$LD_LIBRARY_PATH
-
-RUN mamba install -y -c conda-forge python=3.8 gdal pip setuptools cython numpy
-
-RUN python -m pip install --upgrade pip
 
 # Install common packages
 COPY requirements-task-base.txt /tmp/requirements.txt

--- a/pctasks/ingest_task/Dockerfile
+++ b/pctasks/ingest_task/Dockerfile
@@ -1,36 +1,17 @@
-FROM ubuntu:20.04
+FROM python:3.9-slim
 
 # Setup timezone info
 ENV TZ=UTC
 
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
-
-RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
-
-RUN apt-get update && apt-get install -y software-properties-common
-
-RUN add-apt-repository ppa:ubuntugis/ppa && \
-    apt-get update && \
-    apt-get install -y build-essential python3-dev python3-pip \
-                       jq unzip ca-certificates wget curl && \
-    apt-get autoremove && apt-get autoclean && apt-get clean
-
-RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 10
-
-# See https://github.com/mapbox/rasterio/issues/1289
-ENV CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+ENV PIP_NO_CACHE_DIR=1
 
 RUN python -m pip install --upgrade pip
-
-# Install azure-cli
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
 #
 # Copy and install packages
 #
-
-RUN apt-get install -y git
 
 COPY core /opt/src/core
 RUN cd /opt/src/core && \
@@ -55,12 +36,5 @@ RUN cd /opt/src/ingest && \
 COPY ingest_task /opt/src/ingest_task
 RUN cd /opt/src/ingest_task && \
      pip install .
-
-#
-# Environment configuration
-#
-
-# Setup Python Path
-ENV PYTHONPATH=/opt/src:$PYTHONPATH
 
 WORKDIR /opt/src

--- a/pctasks/run/Dockerfile
+++ b/pctasks/run/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:3.9-slim
 
-RUN apt-get update && \
-    apt-get install -y build-essential git
-
 ENV CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
 ENV PIP_NO_CACHE_DIR=1
 

--- a/requirements-task-base.txt
+++ b/requirements-task-base.txt
@@ -1,2 +1,2 @@
 pystac[validation]==1.*
-rasterio==1.3.0 --no-binary=rasterio
+rasterio==1.3.0


### PR DESCRIPTION
This PR optimzies the various task images (task-base, run, and ingest). It removes *a bunch* of stuff, some of which is probably needed for at least some of our pipelines.

I'm going to do an audit of which pipelines are using which images. I'm also a bit unsure about what sorts of issues are going to be picked up by CI. We might need additional testing to be confident that this doesn't break anything.

Here's the size comparison:

| image             | before | after |
| ----------------- | ------ | ----- |
| pctasks-ingest    | 1.3GB  | 257MB |
| pctasks-run       | 630MB  | 290MB |
| pctasks-task-base | 3.32   | 373MB |
