### PR TITLE
Updating YAML to account for -opendata in ECMWF directories

### DIFF
--- a/datasets/ecmwf-forecast/dataset.yaml
+++ b/datasets/ecmwf-forecast/dataset.yaml
@@ -21,6 +21,7 @@ collections:
       - uri: blob://ai4edataeuwest/ecmwf/
         chunks:
           options:
+            matches: (enfo|oper|waef|wave)(-opendata)?
             extensions: [.grib2]
     chunk_storage:
       uri: blob://ai4edataeuwest/ecmwf-etl-data/pctasks/


### PR DESCRIPTION
## Description

Updated yaml to catch different directory naming conventions as seen on 6/29.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
Ran:
pctasks dataset process-items -d datasets/ecmwf-forecast/dataset.yaml test-20230629 --no-ingest --upsert --submit
against the following blob: blob://ai4edataeuwest/ecmwf/20230629/00z/0p4-beta/

Got the attached .csv. No mention of -opendata.

[uris-list.csv](https://github.com/microsoft/planetary-computer-tasks/files/12099656/uris-list.csv)

