### PR TITLE
Allow spot instances for streaming tasks.

### DIFF
--- a/datasets/goes/goes-cmi/streaming.yaml
+++ b/datasets/goes/goes-cmi/streaming.yaml
@@ -22,6 +22,7 @@ jobs:
             max_replica_count: 10
             polling_interval: 30
             trigger_queue_length: 100
+            allow_spot_instances: true
             resources:
               limits:
                 cpu: "1"

--- a/datasets/goes/goes-cmi/streaming.yaml
+++ b/datasets/goes/goes-cmi/streaming.yaml
@@ -10,7 +10,7 @@ jobs:
     id: create-items
     tasks:
       - id: create-items
-        image: "${{ args.registry }}/pctasks-goes-cmi:2023.7.19.0"
+        image: "${{ args.registry }}/pctasks-goes-cmi:2023.7.26.0"
         task: pctasks.dataset.streaming:StreamingCreateItemsTask
         code:
           src: ${{ local.path(./goes_cmi) }}

--- a/datasets/goes/goes-glm/streaming.yaml
+++ b/datasets/goes/goes-glm/streaming.yaml
@@ -21,6 +21,7 @@ jobs:
             max_replica_count: 10
             polling_interval: 30
             trigger_queue_length: 100
+            allow_spot_instances: true
             resources:
               limits:
                 cpu: "0.25"

--- a/datasets/goes/goes-glm/streaming.yaml
+++ b/datasets/goes/goes-glm/streaming.yaml
@@ -9,7 +9,7 @@ jobs:
     id: create-items
     tasks:
       - id: create-items
-        image: "pccomponentstest.azurecr.io/pctasks-goes-glm:2023.7.20.0"
+        image: "pccomponentstest.azurecr.io/pctasks-goes-glm:2023.7.26.0"
         task: pctasks.dataset.streaming:StreamingCreateItemsTask
         code:
           src: datasets/goes/goes-glm/goes_glm.py

--- a/deployment/terraform/resources/aks.tf
+++ b/deployment/terraform/resources/aks.tf
@@ -10,10 +10,10 @@ resource "azurerm_kubernetes_cluster" "pctasks" {
   }
 
   default_node_pool {
-    name                 = "agentpool"
-    vm_size              = "Standard_DS2_v2"
-    node_count           = var.aks_node_count
-    vnet_subnet_id       = azurerm_subnet.k8snode_subnet.id
+    name           = "agentpool"
+    vm_size        = "Standard_DS2_v2"
+    node_count     = var.aks_node_count
+    vnet_subnet_id = azurerm_subnet.k8snode_subnet.id
 
     node_labels = {
       node_group = "default"
@@ -45,7 +45,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "argowf" {
     node_group = var.argo_wf_node_group_name
   }
 
-   lifecycle {
+  lifecycle {
     ignore_changes = [
       # Ignore changes that are auto-populated by AKS
       vnet_subnet_id,
@@ -65,15 +65,15 @@ resource "azurerm_kubernetes_cluster_node_pool" "tasks" {
   name                  = "tasks"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.pctasks.id
   vm_size               = "Standard_D16d_v4"
-  enable_auto_scaling = true
-  min_count = var.aks_task_pool_min_count
-  max_count = var.aks_task_pool_max_count
+  enable_auto_scaling   = true
+  min_count             = var.aks_task_pool_min_count
+  max_count             = var.aks_task_pool_max_count
 
   node_labels = {
     node_group = var.aks_streaming_task_node_group_name
   }
 
-   lifecycle {
+  lifecycle {
     ignore_changes = [
       # Ignore changes that are auto-populated by AKS
       vnet_subnet_id,
@@ -88,6 +88,44 @@ resource "azurerm_kubernetes_cluster_node_pool" "tasks" {
     ManagedBy   = "AI4E"
   }
 }
+
+resource "azurerm_kubernetes_cluster_node_pool" "tasks-spot" {
+  name                  = "tasksspot"
+  kubernetes_cluster_id = azurerm_kubernetes_cluster.pctasks.id
+  vm_size               = "Standard_D16d_v4"
+  enable_auto_scaling   = true
+  min_count             = var.aks_task_pool_min_count
+  max_count             = var.aks_task_pool_max_count
+
+  # Spot configuration
+  priority        = "Spot"
+  eviction_policy = "Delete"
+  spot_max_price  = -1
+
+  node_labels = {
+    node_group                              = var.aks_streaming_task_node_group_name
+    "kubernetes.azure.com/scalesetpriority" = "spot"
+  }
+  node_taints = [
+    "kubernetes.azure.com/scalesetpriority=spot:NoSchedule",
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes that are auto-populated by AKS
+      vnet_subnet_id,
+      node_taints,
+      zones,
+      node_count,
+    ]
+  }
+
+  tags = {
+    Environment = var.environment
+    ManagedBy   = "AI4E"
+  }
+}
+
 
 
 # add the role to the identity the kubernetes cluster was assigned

--- a/docs/user_guide/streaming.md
+++ b/docs/user_guide/streaming.md
@@ -36,6 +36,28 @@ indefinitely. They should continuously process messages from a queue, and leave
 starting, stopping, and scaling to the pctasks framework (we use Kubernetes
 Deployments and [KEDA] for that).
 
+## Using Spot Nodes
+
+By default, streaming workflows will use regular (non-spot) nodes. To allow a
+streaming workflow to be scheduled on a spot node, set `allow_spot_instances: true`
+in the `args.streaming_options` of the task definition:
+
+```yaml
+jobs:
+  job-name:
+    id: job-id
+    tasks:
+      - id: task-id
+        image: "..."
+        task: "..."
+        args:
+          streaming_options:
+            allow_spot_instances: true
+```
+
+The Kubernetes Pod running this task will *prefer* to run on a preemptible node.
+It will fall back to a regular node group if necessary.
+
 ## Registering a streaming workflow
 
 A streaming workflow is registered with `pctasks` like any other workflow,

--- a/pctasks/run/pctasks/run/workflow/kubernetes.py
+++ b/pctasks/run/pctasks/run/workflow/kubernetes.py
@@ -253,13 +253,13 @@ def build_streaming_deployment(
     if node_group:
         common_labels["node_group"] = node_group
 
-    # TODO: enable node_selector. Disabled for testing in kind.
     allow_spot_instances = task_definition.args["streaming_options"].get(
         "allow_spot_instances", False
     )
     node_selector = {"node_group": node_group} if node_group else None
     tolerations = []
     if node_group:
+        logger.info("Adding node_affinity=%s", node_group)
         affinity = V1Affinity(
             node_affinity=V1NodeAffinity(
                 required_during_scheduling_ignored_during_execution=V1NodeSelector(
@@ -278,6 +278,7 @@ def build_streaming_deployment(
 
         if allow_spot_instances:
             # add a preference for spot instances, if that's allowed
+            logger.info("Adding spot preference")
             affinity.node_affinity.preferred_during_scheduling_ignored_during_execution = [  # noqa: E501
                 V1PreferredSchedulingTerm(
                     weight=1,
@@ -296,6 +297,7 @@ def build_streaming_deployment(
         affinity = None
 
     if allow_spot_instances:
+        logger.info("Adding spot toleration")
         tolerations.append(
             V1Toleration(
                 key="kubernetes.azure.com/scalesetpriority",

--- a/pctasks/task/pctasks/task/streaming.py
+++ b/pctasks/task/pctasks/task/streaming.py
@@ -73,6 +73,7 @@ class StreamingTaskOptions(PCBaseModel):
     polling_interval: int = 30
     trigger_queue_length: int = 100
     message_limit: Optional[int] = None
+    allow_spot_instances: bool = False
     resources: Resources
 
     class Config:


### PR DESCRIPTION
Adds support for using spot instances for streaming tasks.

We add a new node pool to AKS. Same worker type, but has spot priority and the required node labels and taints.

Adds the `allow_spot_instances` to the streaming task workflow definition. By default, spot nodes are not allowed. I think only regular nodes should be used for high-priority tasks like ingesting into the database.

For lower-priority tasks, like creating COGs, and maybe creating STAC items, we can use spot nodes.

The Kubernetes scheduling *should* be set up to just prefer spot nodes when scheduling a Pod. If none are available, it should fall back to regular nodes, but that will need to be confirmed.