### PR TITLE
[low-latency]: Added goes-cmi

### DIFF
--- a/datasets/goes/goes-cmi/streaming.yaml
+++ b/datasets/goes/goes-cmi/streaming.yaml
@@ -1,0 +1,48 @@
+name: "Streaming workflow example"
+
+args:
+  - registry
+  - queue_account_url # "https://pctaskstestdev.queue.core.windows.net"
+  - cosmosdb_url #  "https://cdb-pctaskstest-dev.documents.azure.com:443/"
+
+jobs:
+  create-items:
+    id: create-items
+    tasks:
+      - id: create-items
+        image: "${{ args.registry }}/pctasks-goes-cmi:2023.7.19.0"
+        task: pctasks.dataset.streaming:StreamingCreateItemsTask
+        code:
+          src: ${{ local.path(./goes_cmi) }}
+        args:
+          streaming_options:
+            queue_url: "${{args.queue_account_url}}/goes-cmi"
+            visibility_timeout: 30
+            min_replica_count: 0
+            max_replica_count: 10
+            polling_interval: 30
+            trigger_queue_length: 100
+            resources:
+              limits:
+                cpu: "1"
+                memory: "2Gi"
+              requests:
+                cpu: "0.8"
+                memory: "2Gi"
+
+          options:
+            skip_validation: false
+          create_items_function: goes_cmi.goes_cmi:GoesCmiCollection.create_item
+          collection_id: "goes-cmi"
+
+        environment:
+          AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+          AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+          AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ secrets.task-application-insights-connection-string }}
+          PCTASKS_COSMOSDB__URL: ${{ args.cosmosdb_url }}
+        schema_version: 1.0.0
+is_streaming: True
+schema_version: 1.0.0
+id: goes-cmi-streaming-test
+dataset: goes_cmi

--- a/deployment/terraform/resources/aks.tf
+++ b/deployment/terraform/resources/aks.tf
@@ -64,7 +64,7 @@ resource "azurerm_kubernetes_cluster_node_pool" "argowf" {
 resource "azurerm_kubernetes_cluster_node_pool" "tasks" {
   name                  = "tasks"
   kubernetes_cluster_id = azurerm_kubernetes_cluster.pctasks.id
-  vm_size               = "Standard_D16d_v4"
+  vm_size               = "Standard_D3_v2"
   enable_auto_scaling = true
   min_count = var.aks_task_pool_min_count
   max_count = var.aks_task_pool_max_count

--- a/pctasks/ingest_task/setup.py
+++ b/pctasks/ingest_task/setup.py
@@ -8,7 +8,7 @@ with open("README.md") as f:
 install_requires = [
     "pctasks.task>=0.1.0",
     "pctasks.ingest>=0.1.0",
-    "pypgstac[psycopg]==0.7.3",
+    "pypgstac[psycopg]==0.7.10",
     "pystac>=1.0.0,<2",
     "orjson>=3.5.2",
     "python-dateutil==2.8.2",


### PR DESCRIPTION
This adds a streaming workflow for goes-cmi. It's running in the staging-test deployment:

```
» curl -s
"https://pct-apis-staging.westeurope.cloudapp.azure.com/stac/collections/goes-cmi/items?limit=1"
| jq -r .features[0].properties.datetime
2023-07-25T20:23:55.4Z
```

While tuning the CPU and memory requests for this task, I noticed that we were using a different VM size on the streaming tasks than what we're using on the batch tasks. I think those should match, so I updated streaming to be `D3_v2`.

`goes-cmi` had some bad partitioning state left around in the pct database. We've updated `pctasks.ingest` to depend on `pgstac==0.7.10`