### PR TITLE
[ci/cd]: Fix GHA publishing functions

### DIFF
--- a/deployment/bin/publish_pkgs
+++ b/deployment/bin/publish_pkgs
@@ -144,6 +144,7 @@ upload() {
 }
 
 # Package the scripts and upload to gh-pages
+setup_env
 configure
 package
 update


### PR DESCRIPTION
In https://github.com/microsoft/planetary-computer-tasks/pull/243/, I made some updates to the scripts to allow configuring the CONF_DIR (default /opt/conf) and the directory for the pctasks source (/opt/src).

That implicilty requied calling `setup_env` anywhere you call the bash functions that do the publishing. This updates the GHA that does the function publishing to call setup_env.