### PR TITLE
Added metrics for streaming create items

### DIFF
--- a/datasets/goes/goes-cmi/streaming.yaml
+++ b/datasets/goes/goes-cmi/streaming.yaml
@@ -10,7 +10,7 @@ jobs:
     id: create-items
     tasks:
       - id: create-items
-        image: "${{ args.registry }}/pctasks-goes-cmi:2023.7.26.0"
+        image: "${{ args.registry }}/pctasks-goes-cmi:2023.8.1.0"
         task: pctasks.dataset.streaming:StreamingCreateItemsTask
         code:
           src: ${{ local.path(./goes_cmi) }}

--- a/datasets/goes/goes-glm/streaming.yaml
+++ b/datasets/goes/goes-glm/streaming.yaml
@@ -9,7 +9,7 @@ jobs:
     id: create-items
     tasks:
       - id: create-items
-        image: "pccomponentstest.azurecr.io/pctasks-goes-glm:2023.7.26.0"
+        image: "pccomponentstest.azurecr.io/pctasks-goes-glm:2023.8.1.0"
         task: pctasks.dataset.streaming:StreamingCreateItemsTask
         code:
           src: datasets/goes/goes-glm/goes_glm.py

--- a/datasets/goes/goes-glm/streaming.yaml
+++ b/datasets/goes/goes-glm/streaming.yaml
@@ -1,6 +1,7 @@
 name: "Streaming workflow example"
 
 args:
+  - registry
   - queue_account_url # "https://pctaskstestdev.queue.core.windows.net"
   - cosmosdb_url #  "https://cdb-pctaskstest-dev.documents.azure.com:443/"
 
@@ -9,7 +10,7 @@ jobs:
     id: create-items
     tasks:
       - id: create-items
-        image: "pccomponentstest.azurecr.io/pctasks-goes-glm:2023.8.1.0"
+        image: "${{ args.registry }}/pctasks-goes-glm:2023.8.1.0"
         task: pctasks.dataset.streaming:StreamingCreateItemsTask
         code:
           src: datasets/goes/goes-glm/goes_glm.py

--- a/docs/user_guide/streaming.md
+++ b/docs/user_guide/streaming.md
@@ -79,7 +79,10 @@ the workflow.
 $ pctasks workflow submit '<workflow_id>'
 ```
 
-This will cause the actual compute resources to be created.
+This will cause the actual compute resources to be created. You'll first see an
+Argo Workflow created. That workflow pod is what creates the Kubernetes
+Deployment processing messages from the queue, and the KEDA scaled object
+responsible for scaling the Deployment.
 
 ## Additional Azure Resources
 

--- a/pctasks/dataset/pctasks/dataset/streaming.py
+++ b/pctasks/dataset/pctasks/dataset/streaming.py
@@ -26,7 +26,7 @@ from pctasks.core.models.item import ItemUpdatedRecord, StacItemRecord
 from pctasks.core.models.task import WaitTaskResult
 from pctasks.core.storage import StorageFactory
 from pctasks.core.storage.blob import maybe_rewrite_blob_storage_url
-from pctasks.dataset.items.task import validate_create_items_result
+from pctasks.dataset.items.task import traced_create_item, validate_create_items_result
 from pctasks.task.context import TaskContext
 from pctasks.task.streaming import (
     NoOutput,
@@ -174,7 +174,9 @@ class StreamingCreateItemsTask(
         url = maybe_rewrite_blob_storage_url(url)
         logger.info("Processing url %s", url)
 
-        items = create_items_function(url, storage_factory)
+        with traced_create_item(url, collection_id):
+            items = create_items_function(url, storage_factory)
+
         items = validate_create_items_result(
             items, collection_id=collection_id, skip_validation=skip_validation
         )


### PR DESCRIPTION
Puts the streaming `create_item` call inside a `traced_create_item` context to ensure that we emit metrics on how long it took to run.