### PR TITLE
Users/tom/feature/streaming landsat

### DIFF
--- a/datasets/goes/goes-cmi/streaming.yaml
+++ b/datasets/goes/goes-cmi/streaming.yaml
@@ -17,7 +17,7 @@ jobs:
         args:
           streaming_options:
             queue_url: "${{args.queue_account_url}}/goes-cmi"
-            visibility_timeout: 30
+            visibility_timeout: 300
             min_replica_count: 0
             max_replica_count: 10
             polling_interval: 30

--- a/datasets/landsat/landsat.py
+++ b/datasets/landsat/landsat.py
@@ -51,19 +51,14 @@ class LandsatC2Collection(Collection):
 
         logger.info(f"Creating Item from MTL href: {mtl_path}")
 
-        try:
-            item = stac.create_stac_item(
-                mtl_xml_href=storage.get_authenticated_url(mtl_path),
-                legacy_l8=False,
-                use_usgs_geometry=True,
-                antimeridian_strategy=Strategy.NORMALIZE,
-            )
-            # We provide our own preview thumbnail
-            item.assets.pop("thumbnail", None)
-            item.assets.pop("reduced_resolution_browse", None)
-        except Exception as e:
-            logger.exception(e)
-            logger.info(f"Error creating Item from {asset_uri}", exc_info=True)
-            return []
+        item = stac.create_stac_item(
+            mtl_xml_href=storage.get_authenticated_url(mtl_path),
+            legacy_l8=False,
+            use_usgs_geometry=True,
+            antimeridian_strategy=Strategy.NORMALIZE,
+        )
+        # We provide our own preview thumbnail
+        item.assets.pop("thumbnail", None)
+        item.assets.pop("reduced_resolution_browse", None)
 
         return [item]

--- a/datasets/landsat/streaming.yaml
+++ b/datasets/landsat/streaming.yaml
@@ -1,0 +1,49 @@
+name: "Streaming workflow example"
+
+args:
+  - registry
+  - queue_account_url # "https://pctaskstestdev.queue.core.windows.net"
+  - cosmosdb_url #  "https://cdb-pctaskstest-dev.documents.azure.com:443/"
+
+jobs:
+  create-items:
+    id: create-items
+    tasks:
+      - id: create-items
+        image: "${{ args.registry }}/pctasks-landsat:2023.8.2.0"
+        task: pctasks.dataset.streaming:StreamingCreateItemsTask
+        code:
+          src: ${{ local.path(./landsat.py) }}
+        args:
+          streaming_options:
+            queue_url: "${{args.queue_account_url}}/landsat-c2-l2"
+            visibility_timeout: 30
+            min_replica_count: 0
+            max_replica_count: 10
+            polling_interval: 30
+            trigger_queue_length: 100
+            allow_spot_instances: true
+            resources:
+              limits:
+                cpu: "1"
+                memory: "2Gi"
+              requests:
+                cpu: "0.8"
+                memory: "2Gi"
+
+          options:
+            skip_validation: false
+          create_items_function: landsat:LandsatC2Collection.create_item
+          collection_id: "landsat-c2-l2"
+
+        environment:
+          AZURE_TENANT_ID: ${{ secrets.task-tenant-id }}
+          AZURE_CLIENT_ID: ${{ secrets.task-client-id }}
+          AZURE_CLIENT_SECRET: ${{ secrets.task-client-secret }}
+          APPLICATIONINSIGHTS_CONNECTION_STRING: ${{ secrets.task-application-insights-connection-string }}
+          PCTASKS_COSMOSDB__URL: ${{ args.cosmosdb_url }}
+        schema_version: 1.0.0
+is_streaming: True
+schema_version: 1.0.0
+id: landsat-streaming-test
+dataset: landsat-c2-l2

--- a/deployment/terraform/resources/function.tf
+++ b/deployment/terraform/resources/function.tf
@@ -60,6 +60,10 @@ resource "azurerm_linux_function_app" "pctasks" {
     # Test
     "PCTASKS_DISPATCH__TEST_COLLECTION__QUEUE_NAME" = "test-collection",
     "PCTASKS_DISPATCH__TEST_COLLECTION__PREFIX"     = "http://azurite:10000/devstoreaccount1/",
+    # Landsat-C2-L2
+    "PCTASKS_DISPATCH__LANDSAT_C2_L2_FORECAST__QUEUE_NAME" = "landsat-c2-l2",
+    "PCTASKS_DISPATCH__LANDSAT_C2_L2_FORECAST__PREFIX"     = "https://landsateuwest.blob.core.windows.net/landsat-c2/",
+    "PCTASKS_DISPATCH__LANDSAT_C2_L2_FORECAST__SUFFIX"     = "_MTL.xml",
   }
 
   functions_extension_version = "~4"

--- a/deployment/terraform/resources/storage_account.tf
+++ b/deployment/terraform/resources/storage_account.tf
@@ -55,6 +55,7 @@ resource "azurerm_storage_queue" "queues" {
     "sentinel-1-grd",
     "sentinel-1-rtc",
     "ecmwf-forecast",
+    "landsat-c2-l2",
   ])
   name                 = each.key
   storage_account_name = azurerm_storage_account.pctasks.name

--- a/docs/user_guide/streaming.md
+++ b/docs/user_guide/streaming.md
@@ -58,6 +58,43 @@ jobs:
 The Kubernetes Pod running this task will *prefer* to run on a preemptible node.
 It will fall back to a regular node group if necessary.
 
+## Creating a Streaming Workflow
+
+To add a new streaming workflow, you'll need to:
+
+1. Create a new workflow file called `datasets/{dataset}/streaming.yaml`. You
+   can base it off one of the existing streaming workflow files. Make sure to
+   update the
+
+   - `image`
+   - `code.src`
+   - `args.streaming_options.queue_url`
+   - `args.streaming_options.resources`
+   - `create_items_function`
+   - `collection_id`
+   - `id`
+   - `dataset`
+
+2. Build a new task image if necessary. Make sure its tag matches the tag in the
+   workflow file.
+3. Update the deployment configuration:
+
+    a. Create the Storage Queue by updating `storage_account.tf`
+    b. Add the dispatch rule to `function.tf`
+    c. Add a test case to `pctasks_funcs/tests/test_storage_events.py::test_dispatch`
+    d. redeploy the terraform
+    e. restart the function app?
+
+4. Set up the Event Grid System Topic and Subscription to write to the
+   `storage-events` queue
+5. Deploy the workflow with
+
+   ```
+   pctasks workflow upsert-and-submit datasets/{dataset}/streaming.yaml
+   ```
+
+   including whatever arguments are necessary.
+
 ## Registering a streaming workflow
 
 A streaming workflow is registered with `pctasks` like any other workflow,

--- a/pctasks/core/pctasks/core/storage/blob.py
+++ b/pctasks/core/pctasks/core/storage/blob.py
@@ -370,6 +370,7 @@ class BlobStorage(Storage):
             sas_token = self._generate_container_sas(
                 read=read, list=list, write=write, delete=delete
             )
+        assert sas_token  # for mypy
         base_url = self.get_url(file_path)
         return f"{base_url}?{sas_token.lstrip('?')}"
 

--- a/pctasks/core/pctasks/core/storage/blob.py
+++ b/pctasks/core/pctasks/core/storage/blob.py
@@ -323,11 +323,55 @@ class BlobStorage(Storage):
         else:
             return os.path.join(self.root_uri, file_path)
 
-    def get_authenticated_url(self, file_path: str) -> str:
+    def _generate_container_sas(
+        self,
+        read: bool = True,
+        list: bool = True,
+        write: bool = False,
+        delete: bool = False,
+    ) -> str:
+        """
+        Generate a container-level SAS token.
+
+        This uses the storage instance's BlobServiceClient (and its
+        attached credentials) to generate a container-level SAS token.
+        """
+        start = Datetime.utcnow() - timedelta(hours=10)
+        expiry = Datetime.utcnow() + timedelta(hours=24 * 7)
+        permission = ContainerSasPermissions(
+            read=read,
+            write=write,
+            delete=delete,
+            list=list,
+        )
+        key = self._get_client()._account_client.get_user_delegation_key(
+            key_start_time=start, key_expiry_time=expiry
+        )
+        sas_token = generate_container_sas(
+            self.storage_account_name,
+            self.container_name,
+            user_delegation_key=key,
+            permission=permission,
+            start=start,
+            expiry=expiry,
+        )
+        return sas_token
+
+    def get_authenticated_url(
+        self,
+        file_path: str,
+        read: bool = True,
+        list: bool = True,
+        write: bool = False,
+        delete: bool = False,
+    ) -> str:
+        sas_token = self.sas_token
         if self.sas_token is None:
-            raise SasTokenError(f"SAS Token required but not defined on {self}")
+            sas_token = self._generate_container_sas(
+                read=read, list=list, write=write, delete=delete
+            )
         base_url = self.get_url(file_path)
-        return f"{base_url}?{self.sas_token.lstrip('?')}"
+        return f"{base_url}?{sas_token.lstrip('?')}"
 
     def get_path(self, uri: str) -> str:
         blob_uri = BlobUri(uri)

--- a/pctasks/core/tests/storage/test_blob.py
+++ b/pctasks/core/tests/storage/test_blob.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Tuple
 
 import pytest
 
-from pctasks.core.storage.blob import BlobStorage, maybe_rewrite_blob_storage_url
+from pctasks.core.storage.blob import maybe_rewrite_blob_storage_url
 from pctasks.dev.blob import temp_azurite_blob_storage
 from pctasks.dev.constants import AZURITE_ACCOUNT_NAME, TEST_DATA_CONTAINER
 
@@ -126,10 +126,3 @@ def test_blob_download_timeout():
 def test_maybe_rewrite_blob_storage_url(url, expected):
     result = maybe_rewrite_blob_storage_url(url)
     assert result == expected
-
-
-def test_generate_container_sas():
-    storage = BlobStorage("devstoraccount1", "test-data")
-    result = storage._generate_container_sas()
-
-    assert result

--- a/pctasks/core/tests/storage/test_blob.py
+++ b/pctasks/core/tests/storage/test_blob.py
@@ -4,7 +4,7 @@ from typing import Dict, List, Tuple
 
 import pytest
 
-from pctasks.core.storage.blob import maybe_rewrite_blob_storage_url
+from pctasks.core.storage.blob import BlobStorage, maybe_rewrite_blob_storage_url
 from pctasks.dev.blob import temp_azurite_blob_storage
 from pctasks.dev.constants import AZURITE_ACCOUNT_NAME, TEST_DATA_CONTAINER
 
@@ -126,3 +126,10 @@ def test_blob_download_timeout():
 def test_maybe_rewrite_blob_storage_url(url, expected):
     result = maybe_rewrite_blob_storage_url(url)
     assert result == expected
+
+
+def test_generate_container_sas():
+    storage = BlobStorage("devstoraccount1", "test-data")
+    result = storage._generate_container_sas()
+
+    assert result

--- a/pctasks_funcs/tests/test_storage_events.py
+++ b/pctasks_funcs/tests/test_storage_events.py
@@ -114,6 +114,10 @@ def msg():
             "http://azurite:10000/devstoreaccount1/ABI-L2-CMIPM/2023/096/11/OR_ABI-L2-CMIPM1-M6C10_G16_s20230961135249_e20230961135321_c20230961135389.nc",  # noqa: E501,
             ["test-collection"],
         ),
+        (
+            "https://landsateuwest.blob.core.windows.net/landsat-c2/level-2/standard/oli-tirs/2023/022/028/LC09_L2SP_022028_20230731_20230802_02_T1/LC09_L2SP_022028_20230731_20230802_02_T1_MTL.xml",  # noqa: E501
+            ["landsat-c2-l2"],
+        ),
     ],
 )
 @pytest.mark.usefixtures("dispatch_rules")


### PR DESCRIPTION
## Description

Adds a streaming workflow for landsat-c2-l2.

There are a few extra changes, some of which can be split off.

1. Updated the `create_item` for landsat: https://github.com/microsoft/planetary-computer-tasks/compare/users/tom/feature/streaming-landsat?expand=1#diff-5cf91eee9f0391c827b6dcab7f2969277d8fc5758d57f13e547cd9b486780c68L54. We shouldn't have the main `stac.create_item` in a try/except block. We should fail loudly if there's an error
2. Added documentation for adding a streaming workflow at docs/user_guide/streaming.md
3. Updated `BlobStorage` to support generating a SAS token on the fly. The landsat pipeline relies on passing a URL with a SAS token to `stactools.landsat.stac.create_item`. Previously, `BlobStorage.get_authenticated_url` only worked when the `BlobStorage` instance was created with a SAS token. Note: this needs a test. I've currently fighting with azurite to get some coverage here.
4. Bumped the visiblity timeout for goes-cmi: https://github.com/microsoft/planetary-computer-tasks/compare/users/tom/feature/streaming-landsat?expand=1#diff-943f9dc9d376e556f13d674cf71edde70ff50345acc89ed352fe2e2f510ad68aL20 (some tasks took longer, causing the messages to re-appear in the queue before we delete them)

This is deployed to our test pctasks. Monitor https://pct-apis-staging.westeurope.cloudapp.azure.com/stac/collections/landsat-c2-l2/items for new items. The deployment name in AKS is `pctasksteststaging-landsat-c2-l2-deployment`.