### PR TITLE
Fixed `url` format in log messages

### DIFF
--- a/pctasks_funcs/StorageEventsCF/__init__.py
+++ b/pctasks_funcs/StorageEventsCF/__init__.py
@@ -122,7 +122,7 @@ async def main(documents: func.DocumentList) -> None:
                     "url": storage_event.data.url,
                     "id": storage_event.id,
                     "queue_url": (
-                        f"{queue_client.primary_hostname}/{queue_client.queue_name}",
+                        f"{queue_client.primary_hostname}/{queue_client.queue_name}"
                     ),
                 }
 


### PR DESCRIPTION
## Description

We were including this as a tuple in the log message, not a plain string.