### PR TITLE
[goes-cmi]: Fixed dispatch rules

### DIFF
--- a/deployment/terraform/resources/function.tf
+++ b/deployment/terraform/resources/function.tf
@@ -46,13 +46,28 @@ resource "azurerm_linux_function_app" "pctasks" {
     "PCTASKS_DISPATCH__GOES17_GLM__PREFIX"     = "https://goeseuwest.blob.core.windows.net/noaa-goes17/GLM-L2-LCFA/",
     "PCTASKS_DISPATCH__GOES18_GLM__QUEUE_NAME" = "goes-glm",
     "PCTASKS_DISPATCH__GOES18_GLM__PREFIX"     = "https://goeseuwest.blob.core.windows.net/noaa-goes18/GLM-L2-LCFA/",
-    # GOES-CMI
-    "PCTASKS_DISPATCH__GOES16_CMI__QUEUE_NAME" = "goes-cmi",
-    "PCTASKS_DISPATCH__GOES16_CMI__PREFIX"     = "https://goeseuwest.blob.core.windows.net/noaa-goes16/ABI-L2-CMIPM/",
-    "PCTASKS_DISPATCH__GOES17_CMI__QUEUE_NAME" = "goes-cmi",
-    "PCTASKS_DISPATCH__GOES17_CMI__PREFIX"     = "https://goeseuwest.blob.core.windows.net/noaa-goes17/ABI-L2-CMIPM/",
-    "PCTASKS_DISPATCH__GOES18_CMI__QUEUE_NAME" = "goes-cmi",
-    "PCTASKS_DISPATCH__GOES18_CMI__PREFIX"     = "https://goeseuwest.blob.core.windows.net/noaa-goes18/ABI-L2-CMIPM/",
+    # GOES-CMI - MCMIPC
+    "PCTASKS_DISPATCH__GOES16_MCMIPC__QUEUE_NAME" = "goes-cmi",
+    "PCTASKS_DISPATCH__GOES16_MCMIPC__PREFIX"     = "https://goeseuwest.blob.core.windows.net/noaa-goes16/ABI-L2-MCMIPC/",
+    "PCTASKS_DISPATCH__GOES17_MCMIPC__QUEUE_NAME" = "goes-cmi",
+    "PCTASKS_DISPATCH__GOES17_MCMIPC__PREFIX"     = "https://goeseuwest.blob.core.windows.net/noaa-goes17/ABI-L2-MCMIPC/",
+    "PCTASKS_DISPATCH__GOES18_MCMIPC__QUEUE_NAME" = "goes-cmi",
+    "PCTASKS_DISPATCH__GOES18_MCMIPC__PREFIX"     = "https://goeseuwest.blob.core.windows.net/noaa-goes18/ABI-L2-MCMIPC/",
+    # GOES-CMI - MCMIPM
+    "PCTASKS_DISPATCH__GOES16_MCMIPM__QUEUE_NAME" = "goes-cmi",
+    "PCTASKS_DISPATCH__GOES16_MCMIPM__PREFIX"     = "https://goeseuwest.blob.core.windows.net/noaa-goes16/ABI-L2-MCMIPM/",
+    "PCTASKS_DISPATCH__GOES17_MCMIPM__QUEUE_NAME" = "goes-cmi",
+    "PCTASKS_DISPATCH__GOES17_MCMIPM__PREFIX"     = "https://goeseuwest.blob.core.windows.net/noaa-goes17/ABI-L2-MCMIPM/",
+    "PCTASKS_DISPATCH__GOES18_MCMIPM__QUEUE_NAME" = "goes-cmi",
+    "PCTASKS_DISPATCH__GOES18_MCMIPM__PREFIX"     = "https://goeseuwest.blob.core.windows.net/noaa-goes18/ABI-L2-MCMIPM/",
+    # GOES-CMI - MCMIPF
+    "PCTASKS_DISPATCH__GOES16_MCMIPF__QUEUE_NAME" = "goes-cmi",
+    "PCTASKS_DISPATCH__GOES16_MCMIPF__PREFIX"     = "https://goeseuwest.blob.core.windows.net/noaa-goes16/ABI-L2-MCMIPF/",
+    "PCTASKS_DISPATCH__GOES17_MCMIPF__QUEUE_NAME" = "goes-cmi",
+    "PCTASKS_DISPATCH__GOES17_MCMIPF__PREFIX"     = "https://goeseuwest.blob.core.windows.net/noaa-goes17/ABI-L2-MCMIPF/",
+    "PCTASKS_DISPATCH__GOES18_MCMIPF__QUEUE_NAME" = "goes-cmi",
+    "PCTASKS_DISPATCH__GOES18_MCMIPF__PREFIX"     = "https://goeseuwest.blob.core.windows.net/noaa-goes18/ABI-L2-MCMIPF/",
+
     # ECMWF-forecast
     "PCTASKS_DISPATCH__ECMWF_FORECAST__QUEUE_NAME" = "ecmwf-forecast",
     "PCTASKS_DISPATCH__ECMWF_FORECAST__PREFIX"     = "https://ai4edataeuwest.blob.core.windows.net/ecmwf/",

--- a/docs/user_guide/streaming.md
+++ b/docs/user_guide/streaming.md
@@ -83,7 +83,7 @@ To add a new streaming workflow, you'll need to:
     b. Add the dispatch rule to `function.tf`
     c. Add a test case to `pctasks_funcs/tests/test_storage_events.py::test_dispatch`
     d. redeploy the terraform
-    e. restart the function app?
+    e. restart the function app. Either in the portal or with `az functionapp restart --name '<name>' --resource-group '<resource-group>'`
 
 4. Set up the Event Grid System Topic and Subscription to write to the
    `storage-events` queue

--- a/pctasks_funcs/tests/test_storage_events.py
+++ b/pctasks_funcs/tests/test_storage_events.py
@@ -95,7 +95,15 @@ def msg():
     "url, queue_url",
     [
         (
-            "https://goeseuwest.blob.core.windows.net/noaa-goes16/ABI-L2-CMIPM/2023/096/11/OR_ABI-L2-CMIPM1-M6C10_G16_s20230961135249_e20230961135321_c20230961135389.nc",  # noqa: E501
+            "https://goeseuwest.blob.core.windows.net/noaa-goes18/ABI-L2-MCMIPC/2023/216/12/OR_ABI-L2-MCMIPC-M6_G18_s20232161201191_e20232161203570_c20232161204083.nc",  # noqa: E501
+            ["goes-cmi"],
+        ),
+        (
+            "https://goeseuwest.blob.core.windows.net/noaa-goes18/ABI-L2-MCMIPM/2023/216/11/OR_ABI-L2-MCMIPM2-M6_G18_s20232161147570_e20232161148039_c20232161148111.nc",  # noqa: E501
+            ["goes-cmi"],
+        ),
+        (
+            "https://goeseuwest.blob.core.windows.net/noaa-goes18/ABI-L2-MCMIPF/2023/216/13/OR_ABI-L2-MCMIPF-M6_G18_s20232161310226_e20232161319545_c20232161320015.nc",  # noqa: E501
             ["goes-cmi"],
         ),
         (


### PR DESCRIPTION
This fixes the dispatch rules in goes-cmi to match what we have for its `dataset.yaml`. We match the `MCMIP{C,M,F}` prefix.

We *may* want to introduce a `PCTASKS_DISPATCH__<NAME>__REGEX` concept, which would enable terser rules for dispatch. This  didn't quite warrant that I think.