### PR TITLE
Upgrade k8s version

### DIFF
--- a/deployment/terraform/staging/main.tf
+++ b/deployment/terraform/staging/main.tf
@@ -44,8 +44,8 @@ module "resources" {
   streaming_taskio_sp_client_secret = var.streaming_taskio_sp_client_secret
   streaming_taskio_sp_object_id = var.streaming_taskio_sp_object_id
 
-  k8s_version = "1.25.6"
-  k8s_orchestrator_version = "1.25.6"
+  k8s_version = "1.26.6"
+  k8s_orchestrator_version = "1.26.6"
 
   stac_db_connection_string =  var.stac_db_connection_string
 


### PR DESCRIPTION
## Description

According to the AKS documentation, k8s version 1.25.6 is no longer supported. This change upgrades to 1.26.6.

```
> az aks get-versions --location westeurope --output table
KubernetesVersion    Upgrades
-------------------  ------------------------
1.28.3               None available
1.28.0               1.28.3
1.27.7               1.28.0, 1.28.3
1.27.3               1.27.7, 1.28.0, 1.28.3
1.26.10              1.27.3, 1.27.7
1.26.6               1.26.10, 1.27.3, 1.27.7
1.25.15              1.26.6, 1.26.10
1.25.11              1.25.15, 1.26.6, 1.26.10
```

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)