### PR TITLE
Configure APIM to use external network

### DIFF
--- a/deployment/terraform/resources/apim.tf
+++ b/deployment/terraform/resources/apim.tf
@@ -10,6 +10,12 @@ resource "azurerm_api_management" "pctasks" {
   identity {
     type = "SystemAssigned"
   }
+
+  virtual_network_type = "External"
+  public_ip_address_id = azurerm_public_ip.pctasks_apim.id
+  virtual_network_configuration {
+    subnet_id = azurerm_subnet.apim_subnet.id
+  }
 }
 
 resource "azurerm_key_vault_access_policy" "apim" {

--- a/deployment/terraform/resources/ip.tf
+++ b/deployment/terraform/resources/ip.tf
@@ -18,3 +18,24 @@ resource "azurerm_public_ip" "pctasks" {
     ]
   }
 }
+
+resource "azurerm_public_ip" "pctasks_apim" {
+  name                = "ip-api-${local.prefix}"
+  domain_name_label   = "${local.prefix}-api"
+  resource_group_name = azurerm_resource_group.pctasks.name
+  location            = azurerm_resource_group.pctasks.location
+  allocation_method   = "Static"
+  sku                 = "Standard"
+
+  tags = {
+    environment = var.environment
+  }
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore changes to tags, e.g. because a management agent
+      # updates these based on some ruleset managed elsewhere.
+      tags,
+    ]
+  }
+}

--- a/deployment/terraform/resources/vnet.tf
+++ b/deployment/terraform/resources/vnet.tf
@@ -17,7 +17,7 @@ resource "azurerm_network_security_group" "pctasks" {
     access                     = "Allow"
     protocol                   = "Tcp"
     source_port_range          = "*"
-    destination_port_ranges    = [80,29877,443,29876]
+    destination_port_ranges    = [80,29877,443,3443,29876]
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
@@ -56,5 +56,19 @@ resource "azurerm_subnet" "k8snode_subnet" {
 
 resource "azurerm_subnet_network_security_group_association" "k8snode_subnet" {
   subnet_id                 = azurerm_subnet.k8snode_subnet.id
+  network_security_group_id = azurerm_network_security_group.pctasks.id
+}
+
+# APIM node subnet
+
+resource "azurerm_subnet" "apim_subnet" {
+  name                 = "snet-${local.prefix}-apim"
+  virtual_network_name = azurerm_virtual_network.pctasks.name
+  resource_group_name  = azurerm_resource_group.pctasks.name
+  address_prefixes     = ["10.3.0.0/16"]
+}
+
+resource "azurerm_subnet_network_security_group_association" "apim_subnet" {
+  subnet_id                 = azurerm_subnet.apim_subnet.id
   network_security_group_id = azurerm_network_security_group.pctasks.id
 }

--- a/deployment/terraform/staging/main.tf
+++ b/deployment/terraform/staging/main.tf
@@ -2,59 +2,59 @@ module "resources" {
   source = "../resources"
 
   environment = "staging"
-  region = "West Europe"
+  region      = "West Europe"
 
   pctasks_server_image_tag = "latest"
-  pctasks_run_image_tag = "latest"
+  pctasks_run_image_tag    = "latest"
 
   batch_default_pool_id = var.batch_default_pool_id
 
-  task_acr_resource_group = var.task_acr_resource_group
-  task_acr_name = var.task_acr_name
-  task_acr_sp_object_id = var.task_acr_sp_object_id
+  task_acr_resource_group      = var.task_acr_resource_group
+  task_acr_name                = var.task_acr_name
+  task_acr_sp_object_id        = var.task_acr_sp_object_id
   component_acr_resource_group = var.component_acr_resource_group
-  component_acr_name = var.component_acr_name
+  component_acr_name           = var.component_acr_name
 
-  task_sp_tenant_id = var.task_sp_tenant_id
-  task_sp_object_id = var.task_sp_object_id
-  task_sp_client_id = var.task_sp_client_id
+  task_sp_tenant_id     = var.task_sp_tenant_id
+  task_sp_object_id     = var.task_sp_object_id
+  task_sp_client_id     = var.task_sp_client_id
   task_sp_client_secret = var.task_sp_client_secret
 
   pctasks_task_kv = "kv-pctaskstest-staging"
   # Note: this resource group is managed by terraform but contains the manually managed keyvault
   pctasks_task_kv_resource_group_name = "rg-pctaskstest-staging-westeurope"
 
-  kv_sp_tenant_id = var.kv_sp_tenant_id
-  kv_sp_object_id = var.kv_sp_object_id
-  kv_sp_client_id = var.kv_sp_client_id
+  kv_sp_tenant_id     = var.kv_sp_tenant_id
+  kv_sp_object_id     = var.kv_sp_object_id
+  kv_sp_client_id     = var.kv_sp_client_id
   kv_sp_client_secret = var.kv_sp_client_secret
 
-  deploy_secrets_kv_name = var.deploy_secrets_kv_name
-  deploy_secrets_kv_rg = var.deploy_secrets_kv_rg
-  access_key_secret_name = var.access_key_secret_name
+  deploy_secrets_kv_name         = var.deploy_secrets_kv_name
+  deploy_secrets_kv_rg           = var.deploy_secrets_kv_rg
+  access_key_secret_name         = var.access_key_secret_name
   backend_api_app_id_secret_name = var.backend_api_app_id_secret_name
 
-  pctasks_server_sp_tenant_id = var.pctasks_server_sp_tenant_id
-  pctasks_server_sp_client_id = var.pctasks_server_sp_client_id
+  pctasks_server_sp_tenant_id     = var.pctasks_server_sp_tenant_id
+  pctasks_server_sp_client_id     = var.pctasks_server_sp_client_id
   pctasks_server_sp_client_secret = var.pctasks_server_sp_client_secret
-  pctasks_server_sp_object_id = var.pctasks_server_sp_object_id
+  pctasks_server_sp_object_id     = var.pctasks_server_sp_object_id
 
-  streaming_taskio_sp_tenant_id = var.streaming_taskio_sp_tenant_id
-  streaming_taskio_sp_client_id = var.streaming_taskio_sp_client_id
+  streaming_taskio_sp_tenant_id     = var.streaming_taskio_sp_tenant_id
+  streaming_taskio_sp_client_id     = var.streaming_taskio_sp_client_id
   streaming_taskio_sp_client_secret = var.streaming_taskio_sp_client_secret
-  streaming_taskio_sp_object_id = var.streaming_taskio_sp_object_id
+  streaming_taskio_sp_object_id     = var.streaming_taskio_sp_object_id
 
-  k8s_version = "1.26.6"
+  k8s_version              = "1.26.6"
   k8s_orchestrator_version = "1.26.6"
 
-  stac_db_connection_string =  var.stac_db_connection_string
+  stac_db_connection_string = var.stac_db_connection_string
 
-  cosmosdb_account_name = var.cosmosdb_account_name
+  cosmosdb_account_name   = var.cosmosdb_account_name
   cosmosdb_resource_group = var.cosmosdb_resource_group
 
-  cluster_cert_issuer = "letsencrypt"
-  cluster_cert_server = "https://acme-v02.api.letsencrypt.org/directory"
-  aks_node_count = 2
+  cluster_cert_issuer          = "letsencrypt"
+  cluster_cert_server          = "https://acme-v02.api.letsencrypt.org/directory"
+  aks_node_count               = 2
   pctasks_server_replica_count = 1
-  apim_sku_name = var.apim_sku_name
+  apim_sku_name                = var.apim_sku_name
 }

--- a/deployment/terraform/staging/output.tf
+++ b/deployment/terraform/staging/output.tf
@@ -1,4 +1,4 @@
 output "resources" {
-  value = module.resources
+  value     = module.resources
   sensitive = true
 }

--- a/deployment/terraform/staging/pools.tf
+++ b/deployment/terraform/staging/pools.tf
@@ -18,8 +18,8 @@ module "batch_pool_d3_v3" {
 
   max_increase_per_scale = 50
 
-  acr_name = var.task_acr_name
-  acr_client_id = var.task_acr_sp_client_id
+  acr_name          = var.task_acr_name
+  acr_client_id     = var.task_acr_sp_client_id
   acr_client_secret = var.task_acr_sp_client_secret
 
   subnet_id = module.resources.batch_nodepool_subnet
@@ -43,8 +43,8 @@ module "batch_pool_d3_v3_ingest" {
 
   max_increase_per_scale = 1
 
-  acr_name = var.task_acr_name
-  acr_client_id = var.task_acr_sp_client_id
+  acr_name          = var.task_acr_name
+  acr_client_id     = var.task_acr_sp_client_id
   acr_client_secret = var.task_acr_sp_client_secret
 
   subnet_id = module.resources.batch_nodepool_subnet
@@ -68,8 +68,8 @@ module "batch_pool_d3_v3_high_memory" {
 
   max_increase_per_scale = 1
 
-  acr_name = var.task_acr_name
-  acr_client_id = var.task_acr_sp_client_id
+  acr_name          = var.task_acr_name
+  acr_client_id     = var.task_acr_sp_client_id
   acr_client_secret = var.task_acr_sp_client_secret
 
   subnet_id = module.resources.batch_nodepool_subnet
@@ -93,8 +93,8 @@ module "batch_pool_d3_v3_landsat" {
 
   max_increase_per_scale = 50
 
-  acr_name = var.task_acr_name
-  acr_client_id = var.task_acr_sp_client_id
+  acr_name          = var.task_acr_name
+  acr_client_id     = var.task_acr_sp_client_id
   acr_client_secret = var.task_acr_sp_client_secret
 
   subnet_id = module.resources.batch_nodepool_subnet
@@ -118,8 +118,8 @@ module "batch_pool_d3_v3_s2" {
 
   max_increase_per_scale = 50
 
-  acr_name = var.task_acr_name
-  acr_client_id = var.task_acr_sp_client_id
+  acr_name          = var.task_acr_name
+  acr_client_id     = var.task_acr_sp_client_id
   acr_client_secret = var.task_acr_sp_client_secret
 
   subnet_id = module.resources.batch_nodepool_subnet

--- a/deployment/terraform/staging/variables.tf
+++ b/deployment/terraform/staging/variables.tf
@@ -13,9 +13,9 @@ variable "batch_default_pool_id" {
 }
 
 variable "min_low_priority" {
-    type = number
-    default = 0
-    description = "Minimum number of low priority Batch nodes to keep running"
+  type        = number
+  default     = 0
+  description = "Minimum number of low priority Batch nodes to keep running"
 }
 
 # ACR
@@ -66,51 +66,51 @@ variable "pctasks_run_image_tag" {
 ## Keyvault
 
 variable "task_sp_tenant_id" {
-  type    = string
+  type = string
 }
 
 variable "task_sp_object_id" {
-  type    = string
+  type = string
 }
 
 variable "task_sp_client_id" {
-  type    = string
+  type = string
 }
 
 variable "task_sp_client_secret" {
-  type    = string
+  type = string
 }
 
 variable "kv_sp_tenant_id" {
-  type    = string
+  type = string
 }
 
 variable "kv_sp_object_id" {
-  type    = string
+  type = string
 }
 
 variable "kv_sp_client_id" {
-  type    = string
+  type = string
 }
 
 variable "kv_sp_client_secret" {
-  type    = string
+  type = string
 }
 
 variable "deploy_secrets_kv_name" {
-  type    = string
+  type = string
 }
 
-variable deploy_secrets_kv_rg {
-  type    = string
+variable "deploy_secrets_kv_rg" {
+  type = string
 }
 
-variable access_key_secret_name {
-  type    = string
+variable "access_key_secret_name" {
+  type = string
 }
 
-variable backend_api_app_id_secret_name {
-  type    = string
+variable "backend_api_app_id_secret_name" {
+  type = string
 }
 
 ## Database
@@ -130,35 +130,35 @@ variable "cosmosdb_resource_group" {
 ## PCTasks Server
 
 variable "pctasks_server_sp_tenant_id" {
-  type    = string
+  type = string
 }
 
 variable "pctasks_server_sp_client_id" {
-  type    = string
+  type = string
 }
 
 variable "pctasks_server_sp_client_secret" {
-  type    = string
+  type = string
 }
 
 variable "pctasks_server_sp_object_id" {
-  type    = string
+  type = string
 }
 
 variable "streaming_taskio_sp_client_id" {
-  type    = string
+  type = string
 }
 
 variable "streaming_taskio_sp_client_secret" {
-  type    = string
+  type = string
 }
 
 variable "streaming_taskio_sp_object_id" {
-  type    = string
+  type = string
 }
 
 variable "streaming_taskio_sp_tenant_id" {
-  type    = string
+  type = string
 }
 
 ## AKS


### PR DESCRIPTION
## Description

Configures APIM to use an [external network](https://learn.microsoft.com/en-us/azure/api-management/api-management-using-with-vnet?tabs=stv2). Essentially this deploys the APIM VM instances into the AKS virtual network and creates a new public IP for APIM. 

Fixes # (issue)

This is necessary to comply with Azure internal network security policies.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)