### PR TITLE
Use internal K8S load balancer

### DIFF
--- a/deployment/bin/deploy
+++ b/deployment/bin/deploy
@@ -299,8 +299,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         --create-namespace \
         --set controller.replicaCount=1 \
         --set controller.service.externalTrafficPolicy="Local" \
-        --set controller.service.loadBalancerIP="${INGRESS_IP}" \
-        --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-dns-label-name"="${DNS_LABEL}" \
+        --set controller.service.loadBalancerIP="${INTERNAL_INGRESS_IP}" \
+        --set controller.service.annotations."service\.beta\.kubernetes\.io/azure-load-balancer-internal"=true \
         --wait \
         --timeout 2m0s
 

--- a/deployment/bin/lib
+++ b/deployment/bin/lib
@@ -47,6 +47,7 @@ function gather_tf_output() {
     export ENVIRONMENT=$(tf_output environment)
     export INGRESS_IP=$(tf_output ingress_ip)
     export DNS_LABEL=$(tf_output dns_label)
+    export INTERNAL_INGRESS_IP=$(tf_output internal_ingress_ip)
 
     if [ "${1}" ]; then
         popd

--- a/deployment/terraform/resources/aks.tf
+++ b/deployment/terraform/resources/aks.tf
@@ -9,10 +9,13 @@ resource "azurerm_kubernetes_cluster" "pctasks" {
     log_analytics_workspace_id = azurerm_log_analytics_workspace.pctasks.id
   }
 
+  # https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-node-os-image
+  node_os_channel_upgrade = "NodeImage"
+
   default_node_pool {
     name           = "agentpool"
     vm_size        = "Standard_DS2_v2"
-    os_sku = "AzureLinux"
+    os_sku         = "AzureLinux"
     node_count     = var.aks_node_count
     vnet_subnet_id = azurerm_subnet.k8snode_subnet.id
 

--- a/deployment/terraform/resources/aks.tf
+++ b/deployment/terraform/resources/aks.tf
@@ -9,6 +9,9 @@ resource "azurerm_kubernetes_cluster" "pctasks" {
     log_analytics_workspace_id = azurerm_log_analytics_workspace.pctasks.id
   }
 
+  # https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-cluster#use-cluster-auto-upgrade
+  automatic_channel_upgrade = "rapid"
+
   # https://learn.microsoft.com/en-us/azure/aks/auto-upgrade-node-os-image
   node_os_channel_upgrade = "NodeImage"
 

--- a/deployment/terraform/resources/apim.tf
+++ b/deployment/terraform/resources/apim.tf
@@ -89,7 +89,7 @@ resource "azurerm_api_management_backend" "pctasks" {
   resource_group_name = azurerm_resource_group.pctasks.name
   api_management_name = azurerm_api_management.pctasks.name
   protocol            = "http"
-  url                 = "https://${azurerm_public_ip.pctasks.domain_name_label}.${local.location}.cloudapp.azure.com/"
+  url                 = "https://${var.k8s_vnet_ingress_address}/"
   tls {
     validate_certificate_chain = false
     validate_certificate_name  = false

--- a/deployment/terraform/resources/output.tf
+++ b/deployment/terraform/resources/output.tf
@@ -32,6 +32,10 @@ output "dns_label" {
   value = azurerm_public_ip.pctasks.domain_name_label
 }
 
+output "internal_ingress_ip" {
+  value = var.k8s_vnet_ingress_address
+}
+
 output "cloudapp_hostname" {
   value = "${azurerm_public_ip.pctasks.domain_name_label}.${local.location}.cloudapp.azure.com"
 }

--- a/deployment/terraform/resources/variables.tf
+++ b/deployment/terraform/resources/variables.tf
@@ -27,6 +27,12 @@ variable "k8s_version" {
   type = string
 }
 
+variable "k8s_vnet_ingress_address" {
+  type = string
+  description = "Virtual network address associated with an Azure load balancer associated with a kubernetes ingress controller."
+  default = "10.2.0.15"
+}
+
 variable "k8s_orchestrator_version" {
   type = string
 }


### PR DESCRIPTION
## Description

APIM cannot connect to the public IP of the cluster, therefore we have to use an internal ingress controller to establish network communication.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

`curl https://planetarycomputer-test.microsoft.com/tasks` returns an object from the PCTasks API

## Checklist:

- [x] I have performed a self-review
