### PR TITLE
Add pip install for setuptools>=65.5.1 in Dockerfiles

### DIFF
--- a/Dockerfile.task_base
+++ b/Dockerfile.task_base
@@ -6,6 +6,7 @@ ENV TZ=UTC
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV PIP_NO_CACHE_DIR=1
+RUN pip install "setuptools>=65.5.1"
 
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 

--- a/pctasks/ingest_task/Dockerfile
+++ b/pctasks/ingest_task/Dockerfile
@@ -6,6 +6,7 @@ ENV TZ=UTC
 ENV LC_ALL=C.UTF-8
 ENV LANG=C.UTF-8
 ENV PIP_NO_CACHE_DIR=1
+RUN pip install "setuptools>=65.5.1"
 
 RUN python -m pip install --upgrade pip
 

--- a/pctasks/run/Dockerfile
+++ b/pctasks/run/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.9-slim
 
 ENV CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
 ENV PIP_NO_CACHE_DIR=1
+RUN pip install "setuptools>=65.5.1"
 
 WORKDIR /opt/src
 

--- a/pctasks/server/Dockerfile
+++ b/pctasks/server/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && \
 
 ENV CURL_CA_BUNDLE /etc/ssl/certs/ca-certificates.crt
 ENV PIP_NO_CACHE_DIR=1
+RUN pip install "setuptools>=65.5.1"
 
 WORKDIR /opt/src
 


### PR DESCRIPTION
## Description

The base docker image contains a version of `setuptools` with a vulnerability that must be addressed.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Built the dockerfiles. The fear was that installing a newer `setuptools` would break the container builds but that did not happen.

## Checklist:

- [x] I have performed a self-review
