### PR TITLE
Small changes to deploy to allow for az cli login deployment

### DIFF
--- a/deployment/bin/azlogin
+++ b/deployment/bin/azlogin
@@ -24,9 +24,11 @@ while [[ "$#" -gt 0 ]]; do case $1 in
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
-    az login --service-principal \
+    if ! az account show > /dev/null 2>&1; then
+        az login --service-principal \
         --username ${AZURE_CLIENT_ID} \
         --password ${AZURE_CLIENT_SECRET} \
         --tenant ${AZURE_TENANT_ID}
+    fi
 
 fi

--- a/deployment/bin/deploy
+++ b/deployment/bin/deploy
@@ -31,13 +31,18 @@ Options:
 }
 
 require_env "ARM_SUBSCRIPTION_ID"
-require_env "ARM_TENANT_ID"
-require_env "ARM_CLIENT_ID"
-require_env "ARM_CLIENT_SECRET"
 
-require_env "AZURE_TENANT_ID"
-require_env "AZURE_CLIENT_ID"
-require_env "AZURE_CLIENT_SECRET"
+if [[ "${AZURE_TENANT_ID}" ]]; then
+    export ARM_TENANT_ID=${AZURE_TENANT_ID}
+fi
+
+if [[ "${AZURE_CLIENT_ID}" ]]; then
+    export ARM_CLIENT_ID=${AZURE_CLIENT_ID}
+fi
+
+if [[ "${AZURE_CLIENT_SECRET}" ]]; then
+    export ARM_CLIENT_SECRET=${AZURE_CLIENT_SECRET}
+fi
 
 ###################
 # Parse arguments #

--- a/deployment/bin/lib
+++ b/deployment/bin/lib
@@ -60,6 +60,7 @@ function render_values() {
     bin/jinja ${TF_OUTPUT_FILE} ${TEMPLATE_PATH} ${DEPLOY_VALUES_FILE}
 }
 
+# shellcheck disable=SC2120
 function cluster_login() {
     echo "Logging into the cluster..."
 
@@ -71,10 +72,7 @@ function cluster_login() {
         CLUSTER_NAME=$2
     fi
 
-    az login --service-principal \
-        --username ${ARM_CLIENT_ID} \
-        --password ${ARM_CLIENT_SECRET} \
-        --tenant ${ARM_TENANT_ID}
+    bin/azlogin
 
     az aks get-credentials \
         --resource-group ${RESOURCE_GROUP} \
@@ -87,11 +85,17 @@ function cluster_login() {
     # https://github.com/Azure/kubelogin/issues/87.
     # So we export to a kubeconfig file
     echo "Converting kubeconfig..."
-    kubelogin convert-kubeconfig \
-        --login spn \
-        --client-id ${ARM_CLIENT_ID} \
-        --client-secret ${ARM_CLIENT_SECRET} \
-        --kubeconfig=kubeconfig
+    if [[ "${ARM_CLIENT_ID}" ]]; then
+        kubelogin convert-kubeconfig \
+            --login spn \
+            --client-id ${ARM_CLIENT_ID} \
+            --client-secret ${ARM_CLIENT_SECRET} \
+            --kubeconfig=kubeconfig
+    else
+        kubelogin convert-kubeconfig \
+            --login azurecli \
+            --kubeconfig=kubeconfig
+    fi
     export KUBECONFIG=kubeconfig
 }
 

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -8,14 +8,11 @@ services:
     environment:
       # For Terraform
       - ARM_SUBSCRIPTION_ID=${AZURE_SUBSCRIPTION_ID}
-      - ARM_TENANT_ID=${AZURE_TENANT_ID}
-      - ARM_CLIENT_ID=${AZURE_CLIENT_ID}
-      - ARM_CLIENT_SECRET=${AZURE_CLIENT_SECRET}
 
-      # For Azure CLI
-      - AZURE_TENANT_ID=${AZURE_TENANT_ID}
-      - AZURE_CLIENT_ID=${AZURE_CLIENT_ID}
-      - AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}
+      # For Azure CLI - only set these if not using az login from host
+      - AZURE_TENANT_ID
+      - AZURE_CLIENT_ID
+      - AZURE_CLIENT_SECRET
 
       # Used in function deployment injected by GH Actions
       - GITHUB_TOKEN
@@ -26,3 +23,4 @@ services:
       - ../deployment:/opt/src/deployment
       - ../pctasks:/opt/src/pctasks:ro
       - ../pctasks_funcs:/opt/src/pctasks_funcs:ro
+      - ~/.azure:/root/.azure

--- a/deployment/terraform/resources/vnet.tf
+++ b/deployment/terraform/resources/vnet.tf
@@ -21,6 +21,15 @@ resource "azurerm_network_security_group" "pctasks" {
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
+
+  lifecycle {
+    ignore_changes = [
+      # Ignore security rules, which are added by Azure Core Security
+      # with the description:
+      # Created by Azure Core Security managed policy, placeholder you can delete, please see aka.ms/cainsgpolicy
+      security_rule,
+    ]
+  }
 }
 
 # Batch pool subnet


### PR DESCRIPTION
Changes to the deployment scripts and environment to better enable a workflow that uses the az cli identity for deploying:
- Don't az login if already logged in
- Use azcli kubeconvert if no SP is defined
- Don't require client id/secret in environment

Also, avoid terraform from manipulating manual security rules on the NSG