### PR TITLE
Remove secret from cicd

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -10,9 +10,6 @@ env:
   PCTASKS_COSMOSDB__URL: ${{ secrets.COSMOSDB_URL }}
   PCTASKS_COSMOSDB__KEY: ${{ secrets.COSMOSDB_KEY }}
   PCTASKS_COSMOSDB__TEST_CONTAINER_SUFFIX: ${{ github.run_id }}
-  AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-  AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-  AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
 
 permissions:
   id-token: write
@@ -24,40 +21,40 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: actions/setup-python@v4
-        with:
-          python-version: "3.8"
+      # - uses: actions/setup-python@v4
+      #   with:
+      #     python-version: "3.8"
 
-      - name: Install local dependencies
-        run: ./scripts/install
+      # - name: Install local dependencies
+      #   run: ./scripts/install
 
-      - name: Setup
-        run: ./scripts/setup --no-aux-servers
+      # - name: Setup
+      #   run: ./scripts/setup --no-aux-servers
 
-      - name: Test
-        run: ./scripts/test
+      # - name: Test
+      #   run: ./scripts/test
 
-      - name: Validate collections
-        run: ./scripts/validate-collections
+      # - name: Validate collections
+      #   run: ./scripts/validate-collections
 
-      # Integration Tests
+      # # Integration Tests
 
-      - name: Install Kind
-        uses: helm/kind-action@v1.4.0
-        with:
-          install_only: true
+      # - name: Install Kind
+      #   uses: helm/kind-action@v1.4.0
+      #   with:
+      #     install_only: true
 
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.8.2
-        # if: ${{ github.base_ref  == 'main' }}
+      # - name: Install Helm
+      #   uses: azure/setup-helm@v3
+      #   with:
+      #     version: v3.8.2
+      #   # if: ${{ github.base_ref  == 'main' }}
 
-      - name: Setup cluster
-        run: ./scripts/cluster setup
+      # - name: Setup cluster
+      #   run: ./scripts/cluster setup
 
-      - name: Run integration tests
-        run: ./scripts/citest-integration
+      # - name: Run integration tests
+      #   run: ./scripts/citest-integration
 
       # Publish images
 
@@ -79,15 +76,15 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      - name: Publish images (test)
-        run: ./scripts/publish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}}
+      # - name: Publish images (test)
+      #   run: ./scripts/publish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}}
 
-      - name: Publish images
-        run: ./scripts/publish --acr pccomponents --tag ${{steps.get_image_tag.outputs.tag}}
+      # - name: Publish images
+      #   run: ./scripts/publish --acr pccomponents --tag ${{steps.get_image_tag.outputs.tag}}
 
-      - name: Clean up CosmosDB test containers
-        run: ./scripts/setup --rm-test-containers
-        if: always()
+      # - name: Clean up CosmosDB test containers
+      #   run: ./scripts/setup --rm-test-containers
+      #   if: always()
 
     outputs:
       image_tag: ${{ steps.get_image_tag.outputs.tag }}
@@ -112,5 +109,7 @@ jobs:
         env:
           IMAGE_TAG: ${{needs.build_and_publish.outputs.image_tag}}
           ENVIRONMENT: staging
-          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
-          AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+          ARM_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          ARM_USE_OIDC: true

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -81,7 +81,7 @@ jobs:
 
 
       - name: Publish images (test)
-        run: ./scripts/publish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}} 
+        run: ./scripts/publish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}} --no-login
 
       # - name: Publish images
       #   run: ./scripts/publish --acr pccomponents --tag ${{steps.get_image_tag.outputs.tag}} --no-login

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -24,13 +24,6 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Log in with Azure
-        uses: azure/login@v1
-        with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
-          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-
       - uses: actions/setup-python@v4
         with:
           python-version: "3.8"
@@ -41,30 +34,30 @@ jobs:
       - name: Setup
         run: ./scripts/setup --no-aux-servers
 
-      - name: Test
-        run: ./scripts/test
+      # - name: Test
+      #   run: ./scripts/test
 
-      - name: Validate collections
-        run: ./scripts/validate-collections
+      # - name: Validate collections
+      #   run: ./scripts/validate-collections
 
-      # Integration Tests
+      # # Integration Tests
 
-      - name: Install Kind
-        uses: helm/kind-action@v1.4.0
-        with:
-          install_only: true
+      # - name: Install Kind
+      #   uses: helm/kind-action@v1.4.0
+      #   with:
+      #     install_only: true
 
-      - name: Install Helm
-        uses: azure/setup-helm@v3
-        with:
-          version: v3.8.2
-        # if: ${{ github.base_ref  == 'main' }}
+      # - name: Install Helm
+      #   uses: azure/setup-helm@v3
+      #   with:
+      #     version: v3.8.2
+      #   # if: ${{ github.base_ref  == 'main' }}
 
-      - name: Setup cluster
-        run: ./scripts/cluster setup
+      # - name: Setup cluster
+      #   run: ./scripts/cluster setup
 
-      - name: Run integration tests
-        run: ./scripts/citest-integration
+      # - name: Run integration tests
+      #   run: ./scripts/citest-integration
 
       # Publish images
 
@@ -79,21 +72,23 @@ jobs:
           ;;
           esac
 
-      - name: Log into the ACR (test)
-        run: az acr login --name pccomponentstest
+      - name: Log in with Azure
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
 
       - name: Publish images (test)
         run: ./scripts/publish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}} --no-login
 
-      - name: Log into the ACR
-        run: az acr login --name pccomponents
+      # - name: Publish images
+      #   run: ./scripts/publish --acr pccomponents --tag ${{steps.get_image_tag.outputs.tag}} --no-login
 
-      - name: Publish images
-        run: ./scripts/publish --acr pccomponents --tag ${{steps.get_image_tag.outputs.tag}} --no-login
-
-      - name: Clean up CosmosDB test containers
-        run: ./scripts/setup --rm-test-containers
-        if: always()
+      # - name: Clean up CosmosDB test containers
+      #   run: ./scripts/setup --rm-test-containers
+      #   if: always()
 
     outputs:
       image_tag: ${{ steps.get_image_tag.outputs.tag }}
@@ -105,6 +100,13 @@ jobs:
       - build_and_publish
     steps:
       - uses: actions/checkout@v2
+
+      - name: Log in with Azure
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Deploy
         run: ./scripts/cideploy

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -28,11 +28,11 @@ jobs:
         with:
           python-version: "3.8"
 
-      - name: Install local dependencies
-        run: ./scripts/install
+      # - name: Install local dependencies
+      #   run: ./scripts/install
 
-      - name: Setup
-        run: ./scripts/setup --no-aux-servers
+      # - name: Setup
+      #   run: ./scripts/setup --no-aux-servers
 
       # - name: Test
       #   run: ./scripts/test
@@ -81,7 +81,7 @@ jobs:
 
 
       - name: Publish images (test)
-        run: ./scripts/publish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}} --no-login
+        run: ./scripts/publish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}} 
 
       # - name: Publish images
       #   run: ./scripts/publish --acr pccomponents --tag ${{steps.get_image_tag.outputs.tag}} --no-login

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,7 +2,8 @@ name: CI/CD
 
 on:
   push:
-    branches: [main]
+    # branches: [main]
+    branches: [user/elay/remove-client-secret]
     tags: ["*"]
 
 env:
@@ -12,7 +13,6 @@ env:
   AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
   AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
   AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-  AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
 
 permissions:
   id-token: write
@@ -23,6 +23,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+
+      - name: Log in with Azure
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - uses: actions/setup-python@v4
         with:
@@ -51,7 +58,7 @@ jobs:
         uses: azure/setup-helm@v3
         with:
           version: v3.8.2
-        if: ${{ github.base_ref  == 'main' }}
+        # if: ${{ github.base_ref  == 'main' }}
 
       - name: Setup cluster
         run: ./scripts/cluster setup
@@ -73,19 +80,13 @@ jobs:
           esac
 
       - name: Log into the ACR (test)
-        env:
-          CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-        run: docker login pccomponentstest.azurecr.io --username ${CLIENT_ID} --password ${CLIENT_SECRET}
+        run: az acr login --name pccomponentstest
 
       - name: Publish images (test)
         run: ./scripts/publish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}} --no-login
 
       - name: Log into the ACR
-        env:
-          CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
-          CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-        run: docker login pccomponents.azurecr.io --username ${CLIENT_ID} --password ${CLIENT_SECRET}
+        run: az acr login --name pccomponents
 
       - name: Publish images
         run: ./scripts/publish --acr pccomponents --tag ${{steps.get_image_tag.outputs.tag}} --no-login
@@ -99,7 +100,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    if: ${{ github.ref == 'refs/heads/main' }}
+    # if: ${{ github.ref == 'refs/heads/main' }}
     needs:
       - build_and_publish
     steps:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -21,40 +21,40 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      # - uses: actions/setup-python@v4
-      #   with:
-      #     python-version: "3.8"
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
 
-      # - name: Install local dependencies
-      #   run: ./scripts/install
+      - name: Install local dependencies
+        run: ./scripts/install
 
-      # - name: Setup
-      #   run: ./scripts/setup --no-aux-servers
+      - name: Setup
+        run: ./scripts/setup --no-aux-servers
 
-      # - name: Test
-      #   run: ./scripts/test
+      - name: Test
+        run: ./scripts/test
 
-      # - name: Validate collections
-      #   run: ./scripts/validate-collections
+      - name: Validate collections
+        run: ./scripts/validate-collections
 
-      # # Integration Tests
+      # Integration Tests
 
-      # - name: Install Kind
-      #   uses: helm/kind-action@v1.4.0
-      #   with:
-      #     install_only: true
+      - name: Install Kind
+        uses: helm/kind-action@v1.4.0
+        with:
+          install_only: true
 
-      # - name: Install Helm
-      #   uses: azure/setup-helm@v3
-      #   with:
-      #     version: v3.8.2
-      #   # if: ${{ github.base_ref  == 'main' }}
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.8.2
+        # if: ${{ github.base_ref  == 'main' }}
 
-      # - name: Setup cluster
-      #   run: ./scripts/cluster setup
+      - name: Setup cluster
+        run: ./scripts/cluster setup
 
-      # - name: Run integration tests
-      #   run: ./scripts/citest-integration
+      - name: Run integration tests
+        run: ./scripts/citest-integration
 
       # Publish images
 
@@ -76,15 +76,15 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-      # - name: Publish images (test)
-      #   run: ./scripts/publish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}}
+      - name: Publish images (test)
+        run: ./scripts/publish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}}
 
-      # - name: Publish images
-      #   run: ./scripts/publish --acr pccomponents --tag ${{steps.get_image_tag.outputs.tag}}
+      - name: Publish images
+        run: ./scripts/publish --acr pccomponents --tag ${{steps.get_image_tag.outputs.tag}}
 
-      # - name: Clean up CosmosDB test containers
-      #   run: ./scripts/setup --rm-test-containers
-      #   if: always()
+      - name: Clean up CosmosDB test containers
+        run: ./scripts/setup --rm-test-containers
+        if: always()
 
     outputs:
       image_tag: ${{ steps.get_image_tag.outputs.tag }}

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -2,8 +2,7 @@ name: CI/CD
 
 on:
   push:
-    # branches: [main]
-    branches: [user/elay/remove-client-secret]
+    branches: [main]
     tags: ["*"]
 
 env:
@@ -48,7 +47,7 @@ jobs:
         uses: azure/setup-helm@v3
         with:
           version: v3.8.2
-        # if: ${{ github.base_ref  == 'main' }}
+        if: ${{ github.base_ref  == 'main' }}
 
       - name: Setup cluster
         run: ./scripts/cluster setup
@@ -91,7 +90,7 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
-    # if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs:
       - build_and_publish
     steps:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -28,36 +28,36 @@ jobs:
         with:
           python-version: "3.8"
 
-      # - name: Install local dependencies
-      #   run: ./scripts/install
+      - name: Install local dependencies
+        run: ./scripts/install
 
-      # - name: Setup
-      #   run: ./scripts/setup --no-aux-servers
+      - name: Setup
+        run: ./scripts/setup --no-aux-servers
 
-      # - name: Test
-      #   run: ./scripts/test
+      - name: Test
+        run: ./scripts/test
 
-      # - name: Validate collections
-      #   run: ./scripts/validate-collections
+      - name: Validate collections
+        run: ./scripts/validate-collections
 
-      # # Integration Tests
+      # Integration Tests
 
-      # - name: Install Kind
-      #   uses: helm/kind-action@v1.4.0
-      #   with:
-      #     install_only: true
+      - name: Install Kind
+        uses: helm/kind-action@v1.4.0
+        with:
+          install_only: true
 
-      # - name: Install Helm
-      #   uses: azure/setup-helm@v3
-      #   with:
-      #     version: v3.8.2
-      #   # if: ${{ github.base_ref  == 'main' }}
+      - name: Install Helm
+        uses: azure/setup-helm@v3
+        with:
+          version: v3.8.2
+        # if: ${{ github.base_ref  == 'main' }}
 
-      # - name: Setup cluster
-      #   run: ./scripts/cluster setup
+      - name: Setup cluster
+        run: ./scripts/cluster setup
 
-      # - name: Run integration tests
-      #   run: ./scripts/citest-integration
+      - name: Run integration tests
+        run: ./scripts/citest-integration
 
       # Publish images
 
@@ -79,16 +79,15 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
-
       - name: Publish images (test)
-        run: ./scripts/publish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}} --no-login
+        run: ./scripts/publish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}}
 
-      # - name: Publish images
-      #   run: ./scripts/publish --acr pccomponents --tag ${{steps.get_image_tag.outputs.tag}} --no-login
+      - name: Publish images
+        run: ./scripts/publish --acr pccomponents --tag ${{steps.get_image_tag.outputs.tag}}
 
-      # - name: Clean up CosmosDB test containers
-      #   run: ./scripts/setup --rm-test-containers
-      #   if: always()
+      - name: Clean up CosmosDB test containers
+        run: ./scripts/setup --rm-test-containers
+        if: always()
 
     outputs:
       image_tag: ${{ steps.get_image_tag.outputs.tag }}

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -24,9 +24,9 @@ RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu
 
 RUN apt-get update && apt-get install -y azure-functions-core-tools-4
 
-# Install Terraform 0.14.4
+# Install Terraform 1.8.2
 
-RUN wget -O terraform.zip https://releases.hashicorp.com/terraform/1.1.2/terraform_1.1.2_linux_amd64.zip
+RUN wget -O terraform.zip https://releases.hashicorp.com/terraform/1.8.2/terraform_1.8.2_linux_amd64.zip
 RUN unzip terraform.zip
 RUN mv terraform /usr/local/bin
 

--- a/deployment/bin/deploy
+++ b/deployment/bin/deploy
@@ -33,11 +33,8 @@ Options:
 require_env "ARM_SUBSCRIPTION_ID"
 require_env "ARM_TENANT_ID"
 require_env "ARM_CLIENT_ID"
-require_env "ARM_CLIENT_SECRET"
+require_env "ARM_USE_OIDC"
 
-require_env "AZURE_TENANT_ID"
-require_env "AZURE_CLIENT_ID"
-require_env "AZURE_CLIENT_SECRET"
 
 ###################
 # Parse arguments #

--- a/deployment/bin/deploy
+++ b/deployment/bin/deploy
@@ -112,8 +112,6 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     # Gather environment variables from the terraform directory
     source "${TERRAFORM_DIR}"/env.sh
 
-    bin/azlogin
-
     require_env "DEPLOY_SECRETS_KV"
     require_env "DEPLOY_SECRETS_KV_SECRET"
     require_env "DEPLOY_SECRETS_KV_RG_NAME"

--- a/deployment/bin/lib
+++ b/deployment/bin/lib
@@ -71,11 +71,6 @@ function cluster_login() {
         CLUSTER_NAME=$2
     fi
 
-    az login --service-principal \
-        --username ${ARM_CLIENT_ID} \
-        --password ${ARM_CLIENT_SECRET} \
-        --tenant ${ARM_TENANT_ID}
-
     az aks get-credentials \
         --resource-group ${RESOURCE_GROUP} \
         --name ${CLUSTER_NAME} \
@@ -88,9 +83,7 @@ function cluster_login() {
     # So we export to a kubeconfig file
     echo "Converting kubeconfig..."
     kubelogin convert-kubeconfig \
-        --login spn \
-        --client-id ${ARM_CLIENT_ID} \
-        --client-secret ${ARM_CLIENT_SECRET} \
+        -l azurecli \
         --kubeconfig=kubeconfig
     export KUBECONFIG=kubeconfig
 }

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -7,15 +7,15 @@ services:
       dockerfile: deployment/Dockerfile
     environment:
       # For Terraform
-      - ARM_SUBSCRIPTION_ID=${AZURE_SUBSCRIPTION_ID}
-      - ARM_TENANT_ID=${AZURE_TENANT_ID}
-      - ARM_CLIENT_ID=${AZURE_CLIENT_ID}
-      - ARM_CLIENT_SECRET=${AZURE_CLIENT_SECRET}
-
-      # For Azure CLI
-      - AZURE_TENANT_ID=${AZURE_TENANT_ID}
-      - AZURE_CLIENT_ID=${AZURE_CLIENT_ID}
-      - AZURE_CLIENT_SECRET=${AZURE_CLIENT_SECRET}
+      - ARM_SUBSCRIPTION_ID
+      - ARM_TENANT_ID
+      - ARM_CLIENT_ID
+      - ARM_USE_OIDC
+      - ARM_OIDC_TOKEN
+      - ACTIONS_ID_TOKEN_REQUEST_URL
+      - ACTIONS_ID_TOKEN_REQUEST_TOKEN
+      - ARM_OIDC_REQUEST_TOKEN
+      - ARM_OIDC_REQUEST_URL
 
       # Used in function deployment injected by GH Actions
       - GITHUB_TOKEN
@@ -26,3 +26,4 @@ services:
       - ../deployment:/opt/src/deployment
       - ../pctasks:/opt/src/pctasks:ro
       - ../pctasks_funcs:/opt/src/pctasks_funcs:ro
+      - ~/.azure:/root/.azure

--- a/deployment/terraform/batch_pool/providers.tf
+++ b/deployment/terraform/batch_pool/providers.tf
@@ -1,6 +1,7 @@
 provider azurerm {
   features {}
   skip_provider_registration = true
+  use_oidc = true
 }
 
 terraform {
@@ -9,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.65.0"
+      version = "3.97.1"
     }
   }
 }

--- a/deployment/terraform/resources/keyvault.tf
+++ b/deployment/terraform/resources/keyvault.tf
@@ -9,7 +9,7 @@ resource "azurerm_key_vault_access_policy" "function_app" {
   object_id    = azurerm_linux_function_app.pctasks.identity.0.principal_id
 
   secret_permissions = [
-    "Get", "List", "Set"
+    "Get", "List"
   ]
 }
 

--- a/deployment/terraform/resources/keyvault.tf
+++ b/deployment/terraform/resources/keyvault.tf
@@ -9,7 +9,7 @@ resource "azurerm_key_vault_access_policy" "function_app" {
   object_id    = azurerm_linux_function_app.pctasks.identity.0.principal_id
 
   secret_permissions = [
-    "Get", "List"
+    "Get", "List", "Set"
   ]
 }
 

--- a/deployment/terraform/resources/providers.tf
+++ b/deployment/terraform/resources/providers.tf
@@ -1,6 +1,7 @@
 provider azurerm {
   features {}
   skip_provider_registration = true
+  use_oidc = true
 }
 
 terraform {

--- a/deployment/terraform/resources/providers.tf
+++ b/deployment/terraform/resources/providers.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.65.0"
+      version = "3.97.1"
     }
   }
 }

--- a/deployment/terraform/staging/backend.tf
+++ b/deployment/terraform/staging/backend.tf
@@ -4,5 +4,6 @@ terraform {
     storage_account_name = "pctesttfstate"
     container_name       = "pctasks"
     key                  = "staging.terraform.tfstate"
+    use_oidc             = true
   }
 }


### PR DESCRIPTION
## Description

The motivation of this PR is to remove the client secret in the GitHub actions workflow file cicd.yml to improve security. 
To do this, I reference this [page](https://learn.microsoft.com/en-us/azure/developer/github/connect-from-azure?tabs=azure-portal%2Clinux#add-federated-credentials) and use the federated credentials in service principal which allows authentication without the need for explicit client secret and made corresponding changes to authentication in the workflow.

This PR introduces basically the same code changes as in this [PR](https://github.com/microsoft/planetary-computer-apis/pull/208).

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

I created federated credential for this branch `user/elay/remove-client-secret`, so it can use the service principal to authenticate to Azure. It will be deleted after testing. In cicd.yml , changed branch trigger to  `user/elay/remove-client-secret`
and comment out the if clause, so that `build_and_publish `and `deploy `jobs can all be tested once changes are pushed to this branch instead of main. Check out the [result ](https://github.com/microsoft/planetary-computer-tasks/actions/runs/8989936738)of latest pipeline run and workflow file

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)