### PR TITLE
Fix Helm chart publishing permissions

### DIFF
--- a/.github/workflows/publish-charts-dev.yml
+++ b/.github/workflows/publish-charts-dev.yml
@@ -9,11 +9,11 @@ defaults:
   run:
     shell: bash
 
-permissions:
-  pages: write
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-20.04
 
     steps:

--- a/.github/workflows/publish-charts-dev.yml
+++ b/.github/workflows/publish-charts-dev.yml
@@ -9,7 +9,6 @@ defaults:
   run:
     shell: bash
 
-
 jobs:
   build:
     permissions:

--- a/.github/workflows/publish-charts-dev.yml
+++ b/.github/workflows/publish-charts-dev.yml
@@ -9,6 +9,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  pages: write
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -9,6 +9,9 @@ defaults:
   run:
     shell: bash
 
+permissions:
+  pages: write
+
 jobs:
   build:
     runs-on: ubuntu-20.04

--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -9,11 +9,10 @@ defaults:
   run:
     shell: bash
 
-permissions:
-  pages: write
-
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-20.04
 
     steps:


### PR DESCRIPTION
## Description

The default permissions for Github actions changed at some point and we now need to explicitly grant the job `contents: write` permissions so that it can push a commit to the `gh-pages` branch with the Helm charts to be consumed by OpenPC.

Refs:
1. [What is the GITHUB_TOKEN, is it a secret? Sort of, but not one we have to stop using.](https://docs.github.com/en/actions/security-guides/automatic-token-authentication).
2. [What permissions do actions have?](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/enabling-features-for-your-repository/managing-github-actions-settings-for-a-repository#about-github-actions-permissions-for-your-repository)
3. [How did you know contents: write was the right thing to do?](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions)
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

I manually ran the chart publishing pipeline here: https://github.com/microsoft/planetary-computer-tasks/actions/runs/9114944827

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review