### PR TITLE
Removed task_acr_sp references in deployment

### DIFF
--- a/deployment/terraform/dev/main.tf
+++ b/deployment/terraform/dev/main.tf
@@ -11,7 +11,6 @@ module "resources" {
 
   task_acr_resource_group = var.task_acr_resource_group
   task_acr_name = var.task_acr_name
-  task_acr_sp_object_id = var.task_acr_sp_object_id
   component_acr_resource_group = var.component_acr_resource_group
   component_acr_name = var.component_acr_name
 

--- a/deployment/terraform/dev/pools.tf
+++ b/deployment/terraform/dev/pools.tf
@@ -19,10 +19,11 @@ module "batch_pool_d3_v3" {
   max_increase_per_scale = 50
 
   acr_name = var.task_acr_name
-  acr_client_id = var.task_acr_sp_client_id
-  acr_client_secret = var.task_acr_sp_client_secret
+
+  user_assigned_identity_id = module.resources.batch_user_assigned_identity_id
 
   subnet_id = module.resources.batch_nodepool_subnet
+
 }
 
 module "batch_pool_d3_v3_ingest" {
@@ -44,8 +45,8 @@ module "batch_pool_d3_v3_ingest" {
   max_increase_per_scale = 1
 
   acr_name = var.task_acr_name
-  acr_client_id = var.task_acr_sp_client_id
-  acr_client_secret = var.task_acr_sp_client_secret
+
+  user_assigned_identity_id = module.resources.batch_user_assigned_identity_id
 
   subnet_id = module.resources.batch_nodepool_subnet
 }
@@ -69,8 +70,8 @@ module "batch_pool_d3_v3_high_memory" {
   max_increase_per_scale = 1
 
   acr_name = var.task_acr_name
-  acr_client_id = var.task_acr_sp_client_id
-  acr_client_secret = var.task_acr_sp_client_secret
+
+  user_assigned_identity_id = module.resources.batch_user_assigned_identity_id
 
   subnet_id = module.resources.batch_nodepool_subnet
 }
@@ -94,8 +95,8 @@ module "batch_pool_d3_v2_landsat" {
   max_increase_per_scale = 50
 
   acr_name = var.task_acr_name
-  acr_client_id = var.task_acr_sp_client_id
-  acr_client_secret = var.task_acr_sp_client_secret
+
+  user_assigned_identity_id = module.resources.batch_user_assigned_identity_id
 
   subnet_id = module.resources.batch_nodepool_subnet
 }
@@ -119,8 +120,8 @@ module "batch_pool_d3_v3_s2" {
   max_increase_per_scale = 50
 
   acr_name = var.task_acr_name
-  acr_client_id = var.task_acr_sp_client_id
-  acr_client_secret = var.task_acr_sp_client_secret
+
+  user_assigned_identity_id = module.resources.batch_user_assigned_identity_id
 
   subnet_id = module.resources.batch_nodepool_subnet
 }

--- a/deployment/terraform/dev/variables.tf
+++ b/deployment/terraform/dev/variables.tf
@@ -30,18 +30,6 @@ variable "task_acr_name" {
   default = "pccomponentstest"
 }
 
-variable "task_acr_sp_object_id" {
-  type = string
-}
-
-variable "task_acr_sp_client_id" {
-  type = string
-}
-
-variable "task_acr_sp_client_secret" {
-  type = string
-}
-
 variable "component_acr_resource_group" {
   type    = string
   default = "pc-test-manual-resources"

--- a/deployment/terraform/resources/variables.tf
+++ b/deployment/terraform/resources/variables.tf
@@ -99,10 +99,6 @@ variable "task_acr_name" {
   default = "pccomponentstest"
 }
 
-variable "task_acr_sp_object_id" {
-  type = string
-}
-
 variable "component_acr_resource_group" {
   type    = string
   default = "pc-test-manual-resources"

--- a/deployment/terraform/staging/main.tf
+++ b/deployment/terraform/staging/main.tf
@@ -11,7 +11,6 @@ module "resources" {
 
   task_acr_resource_group      = var.task_acr_resource_group
   task_acr_name                = var.task_acr_name
-  task_acr_sp_object_id        = var.task_acr_sp_object_id
   component_acr_resource_group = var.component_acr_resource_group
   component_acr_name           = var.component_acr_name
 

--- a/deployment/terraform/staging/variables.tf
+++ b/deployment/terraform/staging/variables.tf
@@ -30,18 +30,6 @@ variable "task_acr_name" {
   default = "pccomponentstest"
 }
 
-variable "task_acr_sp_object_id" {
-  type = string
-}
-
-variable "task_acr_sp_client_id" {
-  type = string
-}
-
-variable "task_acr_sp_client_secret" {
-  type = string
-}
-
 variable "component_acr_resource_group" {
   type    = string
   default = "pc-test-manual-resources"

--- a/docs/development/deploying.md
+++ b/docs/development/deploying.md
@@ -55,10 +55,6 @@ Also, you can use the `--skip-fetch-tf-vars` option to `bin/deploy` to skip fetc
 
 __Note:__ If you are using the `terraform/dev` stack, which stores its terraform state locally, a `values.tfvars` will not be pulled from the keyvault. You need to create the `values.tfvars` based on the template and copy it into the `terraform/dev` folder manually.
 
-### Roles
-
-The service principal specified by the `task_acr_sp_object_id` variable must have `AcrPull` permissions on the ACR specified by the `task_acr_name` variable.
-
 ### Azure AD App Registrations
 
 This PC Tasks API and frontend use Azure AD App Registrations to authenticate


### PR DESCRIPTION
I missed a few SP refernces in the terraform. The deployment previously succeeded because these unused values were in the tfvars, but I've since removed them.