### PR TITLE
[ENH]: Allow for matching on the full path

### DIFF
--- a/datasets/ecmwf-forecast/dataset.yaml
+++ b/datasets/ecmwf-forecast/dataset.yaml
@@ -18,7 +18,11 @@ collections:
       - uri: blob://ai4edataeuwest/ecmwf/
         chunks:
           options:
-            matches: (enfo|oper|waef|wave)(?!-opendata)
+            # currently excluding "aifs", in favor of "ifs"
+            # Could put that in a different collection, or modify
+            # the stactools package.
+            matches: /ifs/(0p25|0p4-beta)/(enfo|oper|waef|wave)(?!-opendata)
+            match_full_path: true
             extensions: [.grib2]
     chunk_storage:
       uri: blob://ai4edataeuwest/ecmwf-etl-data/pctasks/

--- a/pctasks/core/pctasks/core/storage/base.py
+++ b/pctasks/core/pctasks/core/storage/base.py
@@ -72,6 +72,7 @@ class Storage(ABC):
         matches: Optional[str] = None,
         walk_limit: Optional[int] = None,
         file_limit: Optional[int] = None,
+        match_full_path: bool = False,
     ) -> Generator[Tuple[str, List[str], List[str]], None, None]:
         """
         Recursively walk storage.
@@ -87,6 +88,9 @@ class Storage(ABC):
             matches: Optional regex that path must match
             walk_limit: Limit the number of times to yield
             file_limit: Limit the number of files returned
+            match_full_path: bool, default False
+                Whether to match on just the file name segment of the path (the default) or
+                the entire path, including the base path.
 
         Returns:
             Generator of (path, files, folders) tuples. Similar to os.walk. Lists

--- a/pctasks/core/pctasks/core/storage/local.py
+++ b/pctasks/core/pctasks/core/storage/local.py
@@ -82,6 +82,7 @@ class LocalStorage(Storage):
         matches: Optional[str] = None,
         walk_limit: Optional[int] = None,
         file_limit: Optional[int] = None,
+        match_full_path: bool = False,
     ) -> Generator[Tuple[str, List[str], List[str]], None, None]:
         def _get_depth(path: str) -> int:
             relpath = os.path.relpath(path, self.base_dir)
@@ -102,7 +103,10 @@ class LocalStorage(Storage):
             if since_date:
                 if since_date > Datetime.fromtimestamp(os.path.getmtime(full_path)):
                     return False
-            return path_filter(p)
+            if match_full_path:
+                return path_filter(full_path)
+            else:
+                return path_filter(p)
 
         for root, folders, files in os.walk(self.base_dir):
 

--- a/pctasks/core/tests/storage/test_blob.py
+++ b/pctasks/core/tests/storage/test_blob.py
@@ -124,3 +124,19 @@ def test_blob_download_timeout():
 def test_maybe_rewrite_blob_storage_url(url, expected):
     result = maybe_rewrite_blob_storage_url(url)
     assert result == expected
+
+
+def test_walk_match_full_path():
+    with temp_azurite_blob_storage(
+        HERE / ".." / "data-files" / "simple-assets"
+    ) as storage:
+        result: Dict[str, Tuple[List[str], List[str]]] = {}
+        for root, folders, files in storage.walk(
+            matches="a/asset-.*.json", match_full_path=True
+        ):
+            result[root] = (folders, files)
+
+        assert set(result.keys()) == {".", "a", "b"}
+        assert set(result["."][0]) == {"a", "b"}
+        assert set(result["a"][1]) == {"asset-a-1.json", "asset-a-2.json"}
+        assert set(result["b"][1]) == set()

--- a/pctasks/core/tests/storage/test_local.py
+++ b/pctasks/core/tests/storage/test_local.py
@@ -41,3 +41,15 @@ def test_fsspec_components():
     storage = LocalStorage(HERE / ".." / "data-files" / "simple-assets")
     assert storage.fsspec_storage_options == {}
     assert storage.fsspec_path("foo/bar.csv") == "file://foo/bar.csv"
+
+
+def test_walk_match_full_path():
+    storage = LocalStorage(HERE / ".." / "data-files" / "simple-assets")
+    subdirs = {
+        root: files
+        for root, _, files in storage.walk(
+            min_depth=1, max_depth=1, matches="a/asset-.*.json", match_full_path=True
+        )
+    }
+    assert subdirs["a"] == ["asset-a-1.json", "asset-a-2.json"]
+    assert subdirs["b"] == []

--- a/pctasks/dataset/pctasks/dataset/chunks/task.py
+++ b/pctasks/dataset/pctasks/dataset/chunks/task.py
@@ -57,6 +57,7 @@ class CreateChunksTask(Task[CreateChunksInput, ChunksOutput]):
             file_limit=input.options.limit,
             max_depth=input.options.max_depth,
             min_depth=input.options.min_depth,
+            match_full_path=input.options.match_full_path,
         ):
             if input.options.list_folders:
                 gen = folders

--- a/pctasks/dataset/pctasks/dataset/models.py
+++ b/pctasks/dataset/pctasks/dataset/models.py
@@ -63,6 +63,9 @@ class ChunkOptions(PCBaseModel):
     matches: Optional[str] = None
     """Only include asset URIs that match this regex."""
 
+    match_full_path: bool = False
+    """Whether to match on just the file name (the default) or the full path."""
+
     limit: Optional[int] = None
     """Limit the number of URIs to process. """
 


### PR DESCRIPTION
This adds a parameter to `Storage.walk`, allowing users to specif whether the `matches` applies just to the filename or to the full path, including the filename.

The same keyword is added to the task and task input, to let this be set in the datasset.yaml.

Recent changes to the data published in the ecmwf container requires a new feature in pctasks' create-chunks: the ability to match on a full path rather than just a filename.

Data are being published under both the

    - <date-prefix>/ifs/...
    - <date-prefix>/aifs/...

We list both sets of data, but our stactools package can't handle the aifs data properly yet. So we want to filter it out.

Previously, `matches` could only target the filename being listed. We need that to filter to specific products. We want to extend that match expression to include the prefix, so that we can filter out the `aifs` data.

## How Has This Been Tested?

In addition to the unit tests, some manual tests to mimic what will run on the server:

```python
# tst.py

from pctasks.dataset.chunks.task import *

input_ = CreateChunksInput.parse_obj(
    {
        "src_uri": "blob://ai4edataeuwest/ecmwf/20240517/00z/",
        "dst_uri": "assets-new",
        "options": {
            "chunk_length": 30000,
            "since": "2024-01-01T10:00:00+00:00",
            "extensions": [".grib2"],
            "matches": "/ifs/(0p25|0p4-beta)/(enfo|oper|waef|wave)(?!-opendata)",
            "match_full_path": True,
            "list_folders": False,
            "chunk_file_name": "uris-list",
            "chunk_extension": ".csv",
        },
    }
)

CreateChunksTask().run(input_, TaskContext(StorageFactory(), "test"))


input_ = CreateChunksInput.parse_obj(
    {
        "src_uri": "blob://ai4edataeuwest/ecmwf/20240517/00z/",
        "dst_uri": "assets-old",
        "options": {
            "chunk_length": 30000,
            "since": "2024-01-01T10:00:00+00:00",
            "extensions": [".grib2"],
            "matches": "/ifs/(0p25|0p4-beta)/(enfo|oper|waef|wave)(?!-opendata)",
            "list_folders": False,
            "chunk_file_name": "uris-list",
            "chunk_extension": ".csv",
        },
    }
)
CreateChunksTask().run(input_, TaskContext(StorageFactory(), "test"))
```

The first run (`match_full_path=True`) outputs files, and we can confirm that there aren't any `aifs` files:

```
cat assets-new/all/ai4edataeuwest/ecmwf/20240517/00z/0/uris-list.csv | grep aifs | wc -l
```

The second one (with `match_full_path` unset, equal to `False` the old behavior) it doesn't match anything.


## Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)