### PR TITLE
Updated ecmwf-forecast image

### DIFF
--- a/datasets/ecmwf-forecast/dataset.yaml
+++ b/datasets/ecmwf-forecast/dataset.yaml
@@ -1,5 +1,5 @@
 id: ecmwf_forecast
-image: ${{ args.registry }}/pctasks-ecmwf-forecast:20240314.1
+image: ${{ args.registry }}/pctasks-ecmwf-forecast:2024.6.13.0
 
 args:
 - registry


### PR DESCRIPTION
This rebuilds the ecmwf-forecast image, which is needed for the new `match_full_path` feature to work.
