### PR TITLE
Set default ttlStrategy for argo pods

### DIFF
--- a/deployment/helm/argo-values.yaml
+++ b/deployment/helm/argo-values.yaml
@@ -12,6 +12,12 @@ controller:
     registry: pccomponentstest.azurecr.io
     repository: argoproj/workflow-controller
     tag: v3.5.7
+  workflowDefaults:
+    spec:
+      ttlStrategy:
+        secondsAfterCompletion: 84600  # 23.5 hours
+      podGC:
+        strategy: OnPodCompletion
 executor:
   image:
     registry: pccomponentstest.azurecr.io


### PR DESCRIPTION
This will ensure that argo pods are cleaned up when they're finished.

I haven't tested a deployment of this yet.