### PR TITLE
Update the List Workflows route to fix nginx 307

### DIFF
--- a/pctasks/server/pctasks/server/routes/workflows.py
+++ b/pctasks/server/pctasks/server/routes/workflows.py
@@ -41,7 +41,7 @@ workflows_router = APIRouter()
 
 
 @workflows_router.get(
-    "/",
+    "",
     summary="List workflows.",
     response_class=ORJSONResponse,
     response_model=WorkflowRecordListResponse,


### PR DESCRIPTION
## Description

The following PR removes the `/` in the List workflows route for pctasks server in order to avoid Temporary redirect.

When going to the pctasks workflows route with a `/` the expected unauthorized response is returned

<img width="361" alt="image" src="https://github.com/user-attachments/assets/72b74e39-c9ab-4c20-aad8-d2a58e91feaa">

However when we remove the `/` at the end of the path we get the following 404 due to a redirect to simply `/workflows/`

<img width="421" alt="image" src="https://github.com/user-attachments/assets/a4cf25fe-f7ed-4d2e-b15a-662c5cbc4f2a">

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

## Checklist:

- [x] I have performed a self-review