### PR TITLE
fix NOAA-cdr numpy version mismatch

### DIFF
--- a/datasets/noaa-cdr/Dockerfile
+++ b/datasets/noaa-cdr/Dockerfile
@@ -29,7 +29,7 @@ RUN curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/downloa
 ENV PATH /opt/conda/bin:$PATH
 ENV LD_LIBRARY_PATH /opt/conda/lib/:$LD_LIBRARY_PATH
 
-RUN mamba install -y -c conda-forge python=3.11 gdal pip setuptools cython numpy
+RUN mamba install -y -c conda-forge python=3.11 gdal pip setuptools cython numpy=1.24.3
 
 RUN python -m pip install --upgrade pip
 

--- a/datasets/noaa-cdr/dataset.yaml
+++ b/datasets/noaa-cdr/dataset.yaml
@@ -1,5 +1,5 @@
 id: noaa-cdr
-image: ${{ args.registry }}/pctasks-noaa-cdr:2026.01.12
+image: ${{ args.registry }}/pctasks-noaa-cdr:2026.05.04
 args:
   - registry
 code:


### PR DESCRIPTION
## Description

PCTasks NOAA-CDR pipeline fails due to numpy version mismatch. Explicitly resolving the numpy version to fix the issue.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [x] Code is linted and styled (./scripts/format)